### PR TITLE
Use BudgetPermissionRequestStatusTracker.cs value object

### DIFF
--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse.cs
@@ -6,4 +6,7 @@ public sealed record GetBudgetPermissionRequestResponse(
     Guid ParticipantId,
     GetBudgetPermissionRequestResponse_PermissionType PermissionType,
     GetBudgetPermissionRequestResponse_Status Status,
-    DateTimeOffset? ExpirationDate);
+    DateTimeOffset ExpirationDate,
+    DateTimeOffset SubmissionDate,
+    DateTimeOffset? CancellationDate,
+    DateTimeOffset? ConfirmationDate);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/Maps/GetBudgetPermissionRequestResponseMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/Maps/GetBudgetPermissionRequestResponseMap.cs
@@ -12,8 +12,11 @@ internal static class GetBudgetPermissionRequestResponseMap
             BudgetId: budgetPermissionRequest.BudgetId.Value,
             ParticipantId: budgetPermissionRequest.ParticipantId.Value,
             PermissionType: MapTo(permissionType: budgetPermissionRequest.PermissionType),
-            Status: MapTo(budgetPermissionRequestStatus: budgetPermissionRequest.Status),
-            ExpirationDate: budgetPermissionRequest.ExpirationDate?.Value);
+            Status: MapTo(budgetPermissionRequestStatus: budgetPermissionRequest.StatusTracker.Status),
+            ExpirationDate: budgetPermissionRequest.StatusTracker.ExpirationDate.Value,
+            SubmissionDate: budgetPermissionRequest.StatusTracker.SubmissionDate.Value,
+            CancellationDate: budgetPermissionRequest.StatusTracker.CancellationDate?.Value,
+            ConfirmationDate: budgetPermissionRequest.StatusTracker.ConfirmationDate?.Value);
     }
 
     private static GetBudgetPermissionRequestResponse_Status MapTo(

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse.cs
@@ -6,4 +6,7 @@ public sealed record GetBudgetPermissionRequestsResponse(
     Guid ParticipantId,
     GetBudgetPermissionRequestsResponse_PermissionType PermissionType,
     GetBudgetPermissionRequestsResponse_Status Status,
-    DateTimeOffset? ExpirationDate);
+    DateTimeOffset ExpirationDate,
+    DateTimeOffset SubmissionDate,
+    DateTimeOffset? CancellationDate,
+    DateTimeOffset? ConfirmationDate);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/Maps/GetBudgetPermissionRequestsResponseMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/Maps/GetBudgetPermissionRequestsResponseMap.cs
@@ -18,8 +18,11 @@ internal static class GetBudgetPermissionRequestsResponseMap
             BudgetId: budgetPermissionRequest.BudgetId.Value,
             ParticipantId: budgetPermissionRequest.ParticipantId.Value,
             PermissionType: MapTo(permissionType: budgetPermissionRequest.PermissionType),
-            Status: MapTo(budgetPermissionRequestStatus: budgetPermissionRequest.Status),
-            ExpirationDate: budgetPermissionRequest.ExpirationDate?.Value);
+            Status: MapTo(budgetPermissionRequestStatus: budgetPermissionRequest.StatusTracker.Status),
+            ExpirationDate: budgetPermissionRequest.StatusTracker.ExpirationDate.Value,
+            SubmissionDate: budgetPermissionRequest.StatusTracker.SubmissionDate.Value,
+            CancellationDate: budgetPermissionRequest.StatusTracker.CancellationDate?.Value,
+            ConfirmationDate: budgetPermissionRequest.StatusTracker.ConfirmationDate?.Value);
     }
 
     private static GetBudgetPermissionRequestsResponse_Status MapTo(

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/CancelAssigningParticipant/CancelAssigningParticipantCommandHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/CancelAssigningParticipant/CancelAssigningParticipantCommandHandler.cs
@@ -2,6 +2,7 @@ using Expenso.BudgetSharing.Domain.BudgetPermissionRequests;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Repositories;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.Shared.Commands;
+using Expenso.Shared.System.Types.Clock;
 using Expenso.Shared.System.Types.Exceptions;
 
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Write.CancelAssigningParticipant;
@@ -9,13 +10,16 @@ namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Write.Cance
 internal sealed class CancelAssigningParticipantCommandHandler : ICommandHandler<CancelAssigningParticipantCommand>
 {
     private readonly IBudgetPermissionRequestRepository _budgetPermissionRequestRepository;
+    private readonly IClock _clock;
 
     public CancelAssigningParticipantCommandHandler(
-        IBudgetPermissionRequestRepository budgetPermissionRequestRepository)
+        IBudgetPermissionRequestRepository budgetPermissionRequestRepository, IClock clock)
     {
         _budgetPermissionRequestRepository = budgetPermissionRequestRepository ??
                                              throw new ArgumentNullException(
                                                  paramName: nameof(budgetPermissionRequestRepository));
+
+        _clock = clock ?? throw new ArgumentNullException(paramName: nameof(clock));
     }
 
     public async Task HandleAsync(CancelAssigningParticipantCommand command, CancellationToken cancellationToken)
@@ -31,7 +35,7 @@ internal sealed class CancelAssigningParticipantCommandHandler : ICommandHandler
                 message: $"Budget permission request with id {command.BudgetPermissionRequestId} hasn't been found");
         }
 
-        budgetPermissionRequest.Cancel();
+        budgetPermissionRequest.Cancel(clock: _clock);
 
         await _budgetPermissionRequestRepository.UpdateAsync(permission: budgetPermissionRequest,
             cancellationToken: cancellationToken);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Rules/ExpirationDateMustBeGreaterThanOneDay.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Rules/ExpirationDateMustBeGreaterThanOneDay.cs
@@ -19,6 +19,6 @@ internal sealed class ExpirationDateMustBeGreaterThanOneDay : IBusinessRule
 
     public bool IsBroken()
     {
-        return _expirationDate < _clock.UtcNow.AddDays(days: 1);
+        return _expirationDate.LessThanOrEqual(dateTimeOffset: _clock.UtcNow.AddDays(days: 1));
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Rules/ExpirationDateMustBeGreaterThanSubmissionDate.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Rules/ExpirationDateMustBeGreaterThanSubmissionDate.cs
@@ -19,6 +19,6 @@ internal sealed class ExpirationDateMustBeGreaterThanSubmissionDate : IBusinessR
 
     public bool IsBroken()
     {
-        return _expirationDate <= _submissionDate;
+        return _expirationDate.LessThanOrEqual(dateTimeOffset: _submissionDate);
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Rules/ExpirationDateMustBeGreaterThanSubmissionDate.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Rules/ExpirationDateMustBeGreaterThanSubmissionDate.cs
@@ -1,0 +1,24 @@
+﻿using Expenso.Shared.Domain.Types.Rules;
+using Expenso.Shared.Domain.Types.ValueObjects;
+
+namespace Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Rules;
+
+internal sealed class ExpirationDateMustBeGreaterThanSubmissionDate : IBusinessRule
+{
+    private readonly DateAndTime _expirationDate;
+    private readonly DateAndTime _submissionDate;
+
+    public ExpirationDateMustBeGreaterThanSubmissionDate(DateAndTime submissionDate, DateAndTime expirationDate)
+    {
+        _submissionDate = submissionDate;
+        _expirationDate = expirationDate;
+    }
+
+    public string Message =>
+        $"Expiration date {_expirationDate.Value} must be greater than Submission date: {_submissionDate.Value}";
+
+    public bool IsBroken()
+    {
+        return _expirationDate <= _submissionDate;
+    }
+}

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/ConfirmParticipantionDomainService.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/ConfirmParticipantionDomainService.cs
@@ -6,6 +6,7 @@ using Expenso.BudgetSharing.Domain.BudgetPermissions;
 using Expenso.BudgetSharing.Domain.BudgetPermissions.Repositories;
 using Expenso.Shared.Domain.Types.Model;
 using Expenso.Shared.Domain.Types.Rules;
+using Expenso.Shared.System.Types.Clock;
 using Expenso.Shared.System.Types.Exceptions;
 using Expenso.UserPreferences.Proxy;
 using Expenso.UserPreferences.Proxy.DTO.API.GetPreference.Response;
@@ -16,10 +17,12 @@ internal sealed class ConfirmParticipantionDomainService : IConfirmParticipantio
 {
     private readonly IBudgetPermissionRepository _budgetPermissionRepository;
     private readonly IBudgetPermissionRequestRepository _budgetPermissionRequestRepository;
+    private readonly IClock _clock;
     private readonly IUserPreferencesProxy _userPreferencesProxy;
 
     public ConfirmParticipantionDomainService(IBudgetPermissionRequestRepository budgetPermissionRequestRepository,
-        IBudgetPermissionRepository budgetPermissionRepository, IUserPreferencesProxy userPreferencesProxy)
+        IBudgetPermissionRepository budgetPermissionRepository, IUserPreferencesProxy userPreferencesProxy,
+        IClock clock)
     {
         _budgetPermissionRepository = budgetPermissionRepository ??
                                       throw new ArgumentNullException(paramName: nameof(budgetPermissionRepository));
@@ -30,6 +33,8 @@ internal sealed class ConfirmParticipantionDomainService : IConfirmParticipantio
 
         _userPreferencesProxy = userPreferencesProxy ??
                                 throw new ArgumentNullException(paramName: nameof(userPreferencesProxy));
+
+        _clock = clock ?? throw new ArgumentNullException(paramName: nameof(clock));
     }
 
     public async Task ConfirmParticipantAsync(Guid budgetPermissionRequestId, CancellationToken cancellationToken)
@@ -75,7 +80,7 @@ internal sealed class ConfirmParticipantionDomainService : IConfirmParticipantio
                     currentPermissions: budgetPermission.Permissions.ToList().AsReadOnly()))
         ]);
 
-        permissionRequest.Confirm();
+        permissionRequest.Confirm(clock: _clock);
 
         budgetPermission.AddPermission(participantId: permissionRequest.ParticipantId,
             permissionType: permissionRequest.PermissionType);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/ValueObjects/BudgetPermissionRequestStatusTracker.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/ValueObjects/BudgetPermissionRequestStatusTracker.cs
@@ -1,0 +1,71 @@
+﻿using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Rules;
+using Expenso.Shared.Domain.Types.Model;
+using Expenso.Shared.Domain.Types.Rules;
+using Expenso.Shared.Domain.Types.ValueObjects;
+using Expenso.Shared.System.Types.Clock;
+
+namespace Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
+
+public sealed record BudgetPermissionRequestStatusTracker
+{
+    private BudgetPermissionRequestStatusTracker()
+    {
+        ExpirationDate = default!;
+        SubmissionDate = default!;
+        ConfirmationDate = default!;
+        CancellationDate = default!;
+        Status = default!;
+    }
+
+    private BudgetPermissionRequestStatusTracker(IClock clock, DateAndTime expirationDate,
+        BudgetPermissionRequestStatus status)
+    {
+        DateAndTime submissionDate = DateAndTime.New(value: clock.UtcNow);
+
+        DomainModelState.CheckBusinessRules(businessRules:
+        [
+            new BusinesRuleCheck(
+                BusinessRule: new UnknownBudgetPermissionRequestStatusCannotBeProcessed(status: status)),
+            new BusinesRuleCheck(
+                BusinessRule: new ExpirationDateMustBeGreaterThanSubmissionDate(expirationDate: expirationDate,
+                    submissionDate: submissionDate))
+        ]);
+
+        ExpirationDate = expirationDate;
+        SubmissionDate = submissionDate;
+        Status = BudgetPermissionRequestStatus.Pending;
+    }
+
+    public DateAndTime ExpirationDate { get; }
+
+    public DateAndTime SubmissionDate { get; }
+
+    public DateAndTime? ConfirmationDate { get; private set; }
+
+    public DateAndTime? CancellationDate { get; private set; }
+
+    public BudgetPermissionRequestStatus Status { get; private set; }
+
+    public static BudgetPermissionRequestStatusTracker Start(IClock clock, DateAndTime expirationDate,
+        BudgetPermissionRequestStatus status)
+    {
+        return new BudgetPermissionRequestStatusTracker(clock: clock, expirationDate: expirationDate, status: status);
+    }
+
+    public void Cancel(IClock clock)
+    {
+        CancellationDate = DateAndTime.New(value: clock.UtcNow);
+        Status = BudgetPermissionRequestStatus.Cancelled;
+    }
+
+    public void Confirm(IClock clock)
+    {
+        ConfirmationDate = DateAndTime.New(value: clock.UtcNow);
+        Status = BudgetPermissionRequestStatus.Confirmed;
+    }
+
+    public void Expire()
+    {
+        Status = BudgetPermissionRequestStatus.Expired;
+    }
+}

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Configurations/BudgetPermissionRequestEntityTypeConfiguration.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Configurations/BudgetPermissionRequestEntityTypeConfiguration.cs
@@ -27,11 +27,40 @@ internal sealed class BudgetPermissionRequestEntityTypeConfiguration : IEntityTy
                 convertFromProviderExpression: x => BudgetId.New(x))
             .IsRequired();
 
-        builder
-            .Property(propertyExpression: x => x.ExpirationDate)
-            .HasConversion(convertToProviderExpression: x => x == null ? (DateTimeOffset?)null : x.Value,
-                convertFromProviderExpression: x => x.HasValue ? DateAndTime.New(x.Value) : null)
-            .IsRequired(required: false);
+        builder.OwnsOne<BudgetPermissionRequestStatusTracker>(navigationExpression: x => x.StatusTracker,
+            buildAction: statusTrackerBuilder =>
+            {
+                statusTrackerBuilder
+                    .Property(propertyExpression: x => x.SubmissionDate)
+                    .HasConversion(convertToProviderExpression: x => x.Value,
+                        convertFromProviderExpression: x => DateAndTime.New(x))
+                    .IsRequired(required: true);
+
+                statusTrackerBuilder
+                    .Property(propertyExpression: x => x.ExpirationDate)
+                    .HasConversion(convertToProviderExpression: x => x.Value,
+                        convertFromProviderExpression: x => DateAndTime.New(x))
+                    .IsRequired(required: true);
+
+                statusTrackerBuilder
+                    .Property(propertyExpression: x => x.ConfirmationDate)
+                    .HasConversion(convertToProviderExpression: x => x == null ? (DateTimeOffset?)null : x.Value,
+                        convertFromProviderExpression: x => x.HasValue ? DateAndTime.New(x.Value) : null)
+                    .IsRequired(required: false);
+
+                statusTrackerBuilder
+                    .Property(propertyExpression: x => x.CancellationDate)
+                    .HasConversion(convertToProviderExpression: x => x == null ? (DateTimeOffset?)null : x.Value,
+                        convertFromProviderExpression: x => x.HasValue ? DateAndTime.New(x.Value) : null)
+                    .IsRequired(required: false);
+
+                statusTrackerBuilder
+                    .Property(propertyExpression: x => x.Status)
+                    .HasConversion(convertToProviderExpression: x => x.Value,
+                        convertFromProviderExpression: x => BudgetPermissionRequestStatus.Create(x))
+                    .HasColumnName(name: "status")
+                    .IsRequired();
+            });
 
         builder
             .Property(propertyExpression: x => x.ParticipantId)
@@ -43,13 +72,6 @@ internal sealed class BudgetPermissionRequestEntityTypeConfiguration : IEntityTy
             .Property(propertyExpression: x => x.PermissionType)
             .HasConversion(convertToProviderExpression: x => x.Value,
                 convertFromProviderExpression: x => PermissionType.Create(x))
-            .IsRequired();
-
-        builder
-            .Property(propertyExpression: x => x.Status)
-            .HasConversion(convertToProviderExpression: x => x.Value,
-                convertFromProviderExpression: x => BudgetPermissionRequestStatus.Create(x))
-            .HasColumnName(name: "status")
             .IsRequired();
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Extensions/BudgetPermissionRequestFilterExtensions.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Extensions/BudgetPermissionRequestFilterExtensions.cs
@@ -34,7 +34,7 @@ public static class BudgetPermissionRequestFilterExtensions
         if (filter.Status != null)
         {
             predicate = AndExpression<BudgetPermissionRequest>.And(leftExpression: predicate,
-                rightExpression: x => x.Status == filter.Status);
+                rightExpression: x => x.StatusTracker.Status == filter.Status);
         }
 
         if (filter.PermissionType != null)

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20240826050223_AddStatusTrackerValueObject.Designer.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20240826050223_AddStatusTrackerValueObject.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Expenso.BudgetSharing.Infrastructure.Persistence.EfCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Expenso.BudgetSharing.Infrastructure.Persistence.EfCore.Migrations
 {
     [DbContext(typeof(BudgetSharingDbContext))]
-    partial class BudgetSharingDbContextModelSnapshot : ModelSnapshot
+    [Migration("20240826050223_AddStatusTrackerValueObject")]
+    partial class AddStatusTrackerValueObject
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20240826050223_AddStatusTrackerValueObject.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20240826050223_AddStatusTrackerValueObject.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Expenso.BudgetSharing.Infrastructure.Persistence.EfCore.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStatusTrackerValueObject : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "ExpirationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                newName: "StatusTracker_ExpirationDate");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "StatusTracker_ExpirationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)),
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "StatusTracker_CancellationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "StatusTracker_ConfirmationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "StatusTracker_SubmissionDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StatusTracker_CancellationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests");
+
+            migrationBuilder.DropColumn(
+                name: "StatusTracker_ConfirmationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests");
+
+            migrationBuilder.DropColumn(
+                name: "StatusTracker_SubmissionDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests");
+
+            migrationBuilder.RenameColumn(
+                name: "StatusTracker_ExpirationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                newName: "ExpirationDate");
+
+            migrationBuilder.AlterColumn<DateTimeOffset>(
+                name: "ExpirationDate",
+                schema: "BudgetSharing",
+                table: "BudgetPermissionRequests",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTimeOffset),
+                oldType: "timestamp with time zone");
+        }
+    }
+}

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Repositories/Write/BudgetPermissionRequestRepository.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Repositories/Write/BudgetPermissionRequestRepository.cs
@@ -31,7 +31,7 @@ internal sealed class BudgetPermissionRequestRepository : IBudgetPermissionReque
             .BudgetPermissionRequests
             .Where(predicate: x => x.BudgetId == budgetId &&
                                    x.ParticipantId == participantId &&
-                                   x.Status == BudgetPermissionRequestStatus.Pending)
+                                   x.StatusTracker.Status == BudgetPermissionRequestStatus.Pending)
             .ToListAsync(cancellationToken: cancellationToken);
     }
 

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Cancel.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Cancel.cs
@@ -15,10 +15,10 @@ internal sealed class Cancel : BudgetPermissionRequestTestBase
         TestCandidate = CreateTestCandidate();
 
         // Act
-        TestCandidate.Cancel();
+        TestCandidate.Cancel(clock: _clockMock.Object);
 
         // Assert
-        TestCandidate.Status.Should().Be(expected: BudgetPermissionRequestStatus.Cancelled);
+        TestCandidate.StatusTracker.Status.Should().Be(expected: BudgetPermissionRequestStatus.Cancelled);
 
         AssertDomainEventPublished(aggregateRoot: TestCandidate, expectedDomainEvents:
         [
@@ -33,11 +33,11 @@ internal sealed class Cancel : BudgetPermissionRequestTestBase
     {
         // Arrange
         TestCandidate = CreateTestCandidate();
-        TestCandidate.Cancel();
+        TestCandidate.Cancel(clock: _clockMock.Object);
 
         // Act
         DomainRuleValidationException? exception =
-            Assert.Throws<DomainRuleValidationException>(code: () => TestCandidate.Cancel());
+            Assert.Throws<DomainRuleValidationException>(code: () => TestCandidate.Cancel(clock: _clockMock.Object));
 
         // Assert
         string expectedExceptionMessage =

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Confirm.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Confirm.cs
@@ -15,10 +15,10 @@ internal sealed class Confirm : BudgetPermissionRequestTestBase
         TestCandidate = CreateTestCandidate();
 
         // Act
-        TestCandidate.Confirm();
+        TestCandidate.Confirm(clock: _clockMock.Object);
 
         // Assert
-        TestCandidate.Status.Should().Be(expected: BudgetPermissionRequestStatus.Confirmed);
+        TestCandidate.StatusTracker.Status.Should().Be(expected: BudgetPermissionRequestStatus.Confirmed);
 
         AssertDomainEventPublished(aggregateRoot: TestCandidate, expectedDomainEvents:
         [
@@ -33,11 +33,11 @@ internal sealed class Confirm : BudgetPermissionRequestTestBase
     {
         // Arrange
         TestCandidate = CreateTestCandidate();
-        TestCandidate.Confirm();
+        TestCandidate.Confirm(clock: _clockMock.Object);
 
         // Act
         DomainRuleValidationException? exception =
-            Assert.Throws<DomainRuleValidationException>(code: () => TestCandidate.Confirm());
+            Assert.Throws<DomainRuleValidationException>(code: () => TestCandidate.Confirm(clock: _clockMock.Object));
 
         // Assert
         string expectedExceptionMessage =

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Create.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Create.cs
@@ -25,17 +25,18 @@ internal sealed class Create : BudgetPermissionRequestTestBase
         TestCandidate.BudgetId.Should().Be(expected: _defaultBudgetId);
         TestCandidate.ParticipantId.Should().Be(expected: _defaultPersonId);
         TestCandidate.PermissionType.Should().Be(expected: _defaultPermissionType);
-        TestCandidate.Status.Should().Be(expected: BudgetPermissionRequestStatus.Pending);
+        TestCandidate.StatusTracker.Status.Should().Be(expected: BudgetPermissionRequestStatus.Pending);
 
         TestCandidate
-            .ExpirationDate.Should()
+            .StatusTracker.ExpirationDate.Should()
             .Be(expected: DateAndTime.New(value: _clockMock.Object.UtcNow.AddDays(days: Expiration)));
 
         AssertDomainEventPublished(aggregateRoot: TestCandidate, expectedDomainEvents:
         [
             new BudgetPermissionRequestedEvent(MessageContext: MessageContextFactoryMock.Object.Current(),
                 OwnerId: TestCandidate.OwnerId, ParticipantId: TestCandidate.ParticipantId,
-                PermissionType: TestCandidate.PermissionType, SubmissionDate: TestCandidate.SubmissionDate)
+                PermissionType: TestCandidate.PermissionType,
+                SubmissionDate: TestCandidate.StatusTracker.SubmissionDate)
         ]);
     }
 

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Expire.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Expire.cs
@@ -18,13 +18,14 @@ internal sealed class Expire : BudgetPermissionRequestTestBase
         TestCandidate.Expire();
 
         // Assert
-        TestCandidate.Status.Should().Be(expected: BudgetPermissionRequestStatus.Expired);
+        TestCandidate.StatusTracker.Status.Should().Be(expected: BudgetPermissionRequestStatus.Expired);
 
         AssertDomainEventPublished(aggregateRoot: TestCandidate, expectedDomainEvents:
         [
             new BudgetPermissionRequestExpiredEvent(MessageContext: MessageContextFactoryMock.Object.Current(),
                 OwnerId: TestCandidate.OwnerId, ParticipantId: TestCandidate.ParticipantId,
-                PermissionType: TestCandidate.PermissionType, ExpirationDate: TestCandidate.ExpirationDate)
+                PermissionType: TestCandidate.PermissionType,
+                ExpirationDate: TestCandidate.StatusTracker.ExpirationDate)
         ]);
     }
 

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantDomainService/AssignParticipantAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantDomainService/AssignParticipantAsync.cs
@@ -37,7 +37,7 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
         budgetPermissionRequest.PermissionType.Should().Be(expected: _permissionType);
 
         budgetPermissionRequest
-            .ExpirationDate?.Value.Should()
+            .StatusTracker.ExpirationDate.Value.Should()
             .BeCloseTo(nearbyTime: _clockMock.Object.UtcNow.AddDays(days: ExpirationDays),
                 precision: TimeSpan.FromMilliseconds(value: 500));
 
@@ -46,7 +46,7 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             new BudgetPermissionRequestedEvent(MessageContext: MessageContextFactoryMock.Object.Current(),
                 OwnerId: budgetPermissionRequest.OwnerId, ParticipantId: budgetPermissionRequest.ParticipantId,
                 PermissionType: budgetPermissionRequest.PermissionType,
-                SubmissionDate: budgetPermissionRequest.SubmissionDate)
+                SubmissionDate: budgetPermissionRequest.StatusTracker.SubmissionDate)
         });
     }
 

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationAsync.cs
@@ -39,7 +39,7 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             cancellationToken: It.IsAny<CancellationToken>());
 
         // Assert
-        _budgetPermissionRequest.Status.Should().Be(expected: BudgetPermissionRequestStatus.Confirmed);
+        _budgetPermissionRequest.StatusTracker.Status.Should().Be(expected: BudgetPermissionRequestStatus.Confirmed);
 
         _budgetPermission
             .Permissions.Should()

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationDomainServiceTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationDomainServiceTestBase.cs
@@ -57,7 +57,7 @@ internal abstract class ConfirmParticipationDomainServiceTestBase : DomainTestBa
         TestCandidate = new ConfirmParticipantionDomainService(
             budgetPermissionRequestRepository: _budgetPermissionRequestRepositoryMock.Object,
             budgetPermissionRepository: _budgetPermissionRepositoryMock.Object,
-            userPreferencesProxy: _userPreferencesProxyMock.Object);
+            userPreferencesProxy: _userPreferencesProxyMock.Object, clock: _clockMock.Object);
 
         // clear uncommitted changes
         _budgetPermissionRequest.GetUncommittedChanges();

--- a/src/Shared/Expenso.Shared.Domain.Types/ValueObjects/DateAndTime.cs
+++ b/src/Shared/Expenso.Shared.Domain.Types/ValueObjects/DateAndTime.cs
@@ -30,98 +30,48 @@ public sealed record DateAndTime
             : new DateAndTime(value: value.Value);
     }
 
-    public static bool operator >(DateAndTime left, DateAndTime right)
+    public static implicit operator DateAndTime(DateTimeOffset dateTimeOffset)
     {
-        return left.Value > right.Value;
+        return New(value: dateTimeOffset);
     }
 
-    public static bool operator <(DateAndTime left, DateAndTime right)
+    public static implicit operator DateTimeOffset(DateAndTime dateAndTime)
     {
-        return left.Value < right.Value;
+        return dateAndTime.Value;
     }
 
-    public static bool operator >=(DateAndTime left, DateAndTime right)
+    public bool GreaterThan(DateAndTime dateTimeOffset)
     {
-        return left.Value >= right.Value;
+        return Value > dateTimeOffset.Value;
     }
 
-    public static bool operator <=(DateAndTime left, DateAndTime right)
+    public bool LessThan(DateAndTime dateTimeOffset)
     {
-        return left.Value <= right.Value;
+        return Value < dateTimeOffset.Value;
     }
 
-    public static bool operator >(DateTimeOffset left, DateAndTime right)
+    public bool GreaterThanOrEqual(DateAndTime dateTimeOffset)
     {
-        return left > right.Value;
+        return Value >= dateTimeOffset.Value;
     }
 
-    public static bool operator <(DateTimeOffset left, DateAndTime right)
+    public bool LessThanOrEqual(DateAndTime dateTimeOffset)
     {
-        return left < right.Value;
+        return Value <= dateTimeOffset.Value;
     }
 
-    public static bool operator >=(DateTimeOffset left, DateAndTime right)
+    public bool Between(DateAndTime start, DateAndTime end)
     {
-        return left >= right.Value;
+        return Value >= start.Value && Value <= end.Value;
     }
 
-    public static bool operator <=(DateTimeOffset left, DateAndTime right)
+    public bool InRange(DateAndTime start, DateAndTime end)
     {
-        return left <= right.Value;
+        return Value >= start.Value && Value <= end.Value;
     }
 
-    public static bool operator >(DateAndTime left, DateTimeOffset right)
+    public bool OutOfRange(DateAndTime start, DateAndTime end)
     {
-        return left.Value > right;
-    }
-
-    public static bool operator <(DateAndTime left, DateTimeOffset right)
-    {
-        return left.Value < right;
-    }
-
-    public static bool operator >=(DateAndTime left, DateTimeOffset right)
-    {
-        return left.Value >= right;
-    }
-
-    public static bool operator <=(DateAndTime left, DateTimeOffset right)
-    {
-        return left.Value <= right;
-    }
-
-    public bool GreaterThan(DateTimeOffset dateTimeOffset)
-    {
-        return Value > dateTimeOffset;
-    }
-
-    public bool LessThan(DateTimeOffset dateTimeOffset)
-    {
-        return Value < dateTimeOffset;
-    }
-
-    public bool GreaterThanOrEqual(DateTimeOffset dateTimeOffset)
-    {
-        return Value >= dateTimeOffset;
-    }
-
-    public bool LessThanOrEqual(DateTimeOffset dateTimeOffset)
-    {
-        return Value <= dateTimeOffset;
-    }
-
-    public bool Between(DateTimeOffset start, DateTimeOffset end)
-    {
-        return Value >= start && Value <= end;
-    }
-
-    public bool InRange(DateTimeOffset start, DateTimeOffset end)
-    {
-        return Value >= start && Value <= end;
-    }
-
-    public bool OutOfRange(DateTimeOffset start, DateTimeOffset end)
-    {
-        return Value < start || Value > end;
+        return Value < start.Value || Value > end.Value;
     }
 }

--- a/src/Shared/Expenso.Shared.Domain.Types/ValueObjects/DateAndTime.cs
+++ b/src/Shared/Expenso.Shared.Domain.Types/ValueObjects/DateAndTime.cs
@@ -30,6 +30,26 @@ public sealed record DateAndTime
             : new DateAndTime(value: value.Value);
     }
 
+    public static bool operator >(DateAndTime left, DateAndTime right)
+    {
+        return left.Value > right.Value;
+    }
+
+    public static bool operator <(DateAndTime left, DateAndTime right)
+    {
+        return left.Value < right.Value;
+    }
+
+    public static bool operator >=(DateAndTime left, DateAndTime right)
+    {
+        return left.Value >= right.Value;
+    }
+
+    public static bool operator <=(DateAndTime left, DateAndTime right)
+    {
+        return left.Value <= right.Value;
+    }
+
     public static bool operator >(DateTimeOffset left, DateAndTime right)
     {
         return left > right.Value;

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/Between.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/Between.cs
@@ -1,0 +1,38 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class Between : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsBetweenStartAndEnd()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset start = dateTimeOffset.Value.AddHours(hours: -1);
+        DateTimeOffset end = dateTimeOffset.Value.AddHours(hours: 1);
+
+        // Act
+        bool result = dateTimeOffset.Between(start: start, end: end);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsNotBetweenStartAndEnd()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset start = dateTimeOffset.Value.AddHours(hours: 1);
+        DateTimeOffset end = dateTimeOffset.Value.AddHours(hours: 2);
+
+        // Act
+        bool result = dateTimeOffset.Between(start: start, end: end);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/DateAndTimeTestBase.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/DateAndTimeTestBase.cs
@@ -1,0 +1,5 @@
+﻿using TestCandidate = Expenso.Shared.Domain.Types.ValueObjects.DateAndTime;
+
+namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal abstract class DateAndTimeTestBase : TestBase<TestCandidate>;

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/GreaterThan.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/GreaterThan.cs
@@ -1,0 +1,36 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class GreaterThan : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsGreaterThanGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value.AddHours(hours: -1);
+
+        // Act
+        bool result = dateTimeOffset.GreaterThan(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsLessThanOrEqualToGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value.AddHours(hours: 1);
+
+        // Act
+        bool result = dateTimeOffset.GreaterThan(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/GreaterThanOrEqual.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/GreaterThanOrEqual.cs
@@ -1,0 +1,36 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class GreaterThanOrEqual : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsGreaterThanOrEqualToGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value;
+
+        // Act
+        bool result = dateTimeOffset.GreaterThanOrEqual(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsLessThanGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value.AddHours(hours: 1);
+
+        // Act
+        bool result = dateTimeOffset.GreaterThanOrEqual(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/InRange.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/InRange.cs
@@ -1,0 +1,38 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class InRange : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsWithinRange()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset start = dateTimeOffset.Value.AddHours(hours: -1);
+        DateTimeOffset end = dateTimeOffset.Value.AddHours(hours: 1);
+
+        // Act
+        bool result = dateTimeOffset.InRange(start: start, end: end);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsNotWithinRange()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset start = dateTimeOffset.Value.AddHours(hours: 1);
+        DateTimeOffset end = dateTimeOffset.Value.AddHours(hours: 2);
+
+        // Act
+        bool result = dateTimeOffset.InRange(start: start, end: end);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/LessThan.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/LessThan.cs
@@ -1,0 +1,36 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class LessThan : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsLessThanGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value.AddHours(hours: 1);
+
+        // Act
+        bool result = dateTimeOffset.LessThan(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsGreaterThanOrEqualToGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value.AddHours(hours: -1);
+
+        // Act
+        bool result = dateTimeOffset.LessThan(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/LessThanOrEqual.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/LessThanOrEqual.cs
@@ -12,7 +12,7 @@ internal sealed class LessThanOrEqual : DateAndTimeTestBase
         DateTimeOffset other = dateTimeOffset.Value;
 
         // Act
-        bool result = dateTimeOffset.LessThanOrEqual(dateTimeOffset: other);
+        bool result = dateTimeOffset <= other;
 
         // Assert
         result.Should().BeTrue();

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/LessThanOrEqual.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/LessThanOrEqual.cs
@@ -1,0 +1,36 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class LessThanOrEqual : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsLessThanOrEqualToGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value;
+
+        // Act
+        bool result = dateTimeOffset.LessThanOrEqual(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsGreaterThanGivenDateTimeOffset()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset other = dateTimeOffset.Value.AddHours(hours: -1);
+
+        // Act
+        bool result = dateTimeOffset.LessThanOrEqual(dateTimeOffset: other);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/New.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/New.cs
@@ -1,0 +1,37 @@
+﻿using Expenso.Shared.Domain.Types.Exceptions;
+
+namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class New : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnsValidDateTimeOffset()
+    {
+        // Arrange
+        DateTimeOffset dateTimeOffset = DateTimeOffset.Now;
+
+        // Act
+        Shared.Domain.Types.ValueObjects.DateAndTime result =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: dateTimeOffset);
+
+        // Assert
+        result.Value.Should().Be(expected: dateTimeOffset);
+    }
+
+    [Test]
+    public void Should_ThrowBusinessRuleException_When_DateTimeOffsetIsEmpty()
+    {
+        // Arrange
+        DateTimeOffset emptyDateTimeOffset = DateTimeOffset.MinValue;
+
+        // Act & Assert
+        DomainRuleValidationException? ex = Assert.Throws<DomainRuleValidationException>(code: () =>
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: emptyDateTimeOffset));
+
+        // Assert
+        Assert.That(actual: ex?.Message,
+            expression: Is.EqualTo(
+                expected:
+                $"Empty date and time {nameof(Shared.Domain.Types.ValueObjects.DateAndTime)} cannot be processed"));
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/Nullable.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/Nullable.cs
@@ -1,0 +1,52 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class Nullable : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnNull_When_ValueIsNull()
+    {
+        // Act
+        Shared.Domain.Types.ValueObjects.DateAndTime? result =
+            Shared.Domain.Types.ValueObjects.DateAndTime.Nullable(value: null);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void Should_ReturnNull_When_ValueIsMinValue()
+    {
+        // Act
+        Shared.Domain.Types.ValueObjects.DateAndTime? result =
+            Shared.Domain.Types.ValueObjects.DateAndTime.Nullable(value: DateTimeOffset.MinValue);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void Should_ReturnNull_When_ValueIsMaxValue()
+    {
+        // Act
+        Shared.Domain.Types.ValueObjects.DateAndTime? result =
+            Shared.Domain.Types.ValueObjects.DateAndTime.Nullable(value: DateTimeOffset.MaxValue);
+
+        // Assert
+        result.Should().BeNull();
+    }
+
+    [Test]
+    public void Should_ReturnsValidDateAndTime_When_ValueIsValid()
+    {
+        // Arrange
+        DateTimeOffset dateTimeOffset = DateTimeOffset.Now;
+
+        // Act
+        Shared.Domain.Types.ValueObjects.DateAndTime? result =
+            Shared.Domain.Types.ValueObjects.DateAndTime.Nullable(value: dateTimeOffset);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Value.Should().Be(expected: dateTimeOffset);
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/Nullable.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/Nullable.cs
@@ -47,6 +47,6 @@ internal sealed class Nullable : DateAndTimeTestBase
 
         // Assert
         result.Should().NotBeNull();
-        result.Value.Should().Be(expected: dateTimeOffset);
+        result?.Value.Should().Be(expected: dateTimeOffset);
     }
 }

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/OutOfRange.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/Domain/Types/ValueObjects/DateAndTime/OutOfRange.cs
@@ -1,0 +1,38 @@
+﻿namespace Expenso.Shared.Tests.UnitTests.Domain.Types.ValueObjects.DateAndTime;
+
+internal sealed class OutOfRange : DateAndTimeTestBase
+{
+    [Test]
+    public void Should_ReturnTrue_When_ValueIsOutsideRange()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset start = dateTimeOffset.Value.AddHours(hours: 1);
+        DateTimeOffset end = dateTimeOffset.Value.AddHours(hours: 2);
+
+        // Act
+        bool result = dateTimeOffset.OutOfRange(start: start, end: end);
+
+        // Assert
+        result.Should().BeTrue();
+    }
+
+    [Test]
+    public void Should_ReturnFalse_When_ValueIsWithinRange()
+    {
+        // Arrange
+        Shared.Domain.Types.ValueObjects.DateAndTime dateTimeOffset =
+            Shared.Domain.Types.ValueObjects.DateAndTime.New(value: DateTimeOffset.Now);
+
+        DateTimeOffset start = dateTimeOffset.Value.AddHours(hours: -1);
+        DateTimeOffset end = dateTimeOffset.Value.AddHours(hours: 1);
+
+        // Act
+        bool result = dateTimeOffset.OutOfRange(start: start, end: end);
+
+        // Assert
+        result.Should().BeFalse();
+    }
+}

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/System/Serialization/DefaultSerializer/Deserialize.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/System/Serialization/DefaultSerializer/Deserialize.cs
@@ -5,7 +5,7 @@ namespace Expenso.Shared.Tests.UnitTests.System.Serialization.DefaultSerializer;
 internal sealed class Deserialize : DefaultSerializerTestBase
 {
     [Test]
-    public void DeserializeBasicObject_Always_ShouldDeserializeObject()
+    public void Should_Always_DeserializeBasicObject()
     {
         // Arrange
         string serializedObj = TestCandidate.Serialize(value: BasicObject);
@@ -18,7 +18,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeBasicObjectWithOptions_Always_ShouldDeserializeObject()
+    public void Should_DeserializeBasicObject_WithOptions()
     {
         // Arrange
         // Act
@@ -33,7 +33,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeBasicObject_Always_ShouldDeserializeObjectWithCustomType()
+    public void Should_DeserializeBasicObject_WithCustomType()
     {
         // Arrange
         string serializedObj = TestCandidate.Serialize(value: BasicObject);
@@ -47,7 +47,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeBasicObject_Always_ShouldDeserializeObjectWithUnspecifiedType()
+    public void Should_DeserializeBasicObject_WithUnspecifiedType()
     {
         // Arrange
         string serializedObj = TestCandidate.Serialize(value: BasicObject);
@@ -60,7 +60,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeBasicObjectWithOptions_Always_ShouldDeserializeObjectWithUnspecifiedType()
+    public void Should_DeserializeBasicObject_WithUnspecifiedTypeAndOptions()
     {
         // Arrange
         // Act
@@ -75,7 +75,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeComplexObject_Always_ShouldDeserializeObject()
+    public void Should_DeserializeComplexObject_Always()
     {
         // Arrange
         string serializedObj = TestCandidate.Serialize(value: ComplexObject);
@@ -88,7 +88,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeComplexObjectWithOptions_Always_ShouldDeserializeObject()
+    public void Should_DeserializeComplexObject_WithOptions()
     {
         // Arrange
         // Act
@@ -103,7 +103,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeComplexObject_Always_ShouldDeserializeObjectWithCustomType()
+    public void Should_DeserializeComplexObject_WithCustomType()
     {
         // Arrange
         string serializedObj = TestCandidate.Serialize(value: ComplexObject);
@@ -117,7 +117,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeComplexObject_Always_ShouldDeserializeObjectWithUnspecifiedType()
+    public void Should_DeserializeComplexObject_WithUnspecifiedType()
     {
         // Arrange
         string serializedObj = TestCandidate.Serialize(value: ComplexObject);
@@ -130,7 +130,7 @@ internal sealed class Deserialize : DefaultSerializerTestBase
     }
 
     [Test]
-    public void DeserializeComplexObjectWithOptions_Always_ShouldDeserializeObjectWithUnspecifiedType()
+    public void Should_DeserializeComplexObject_WithUnspecifiedTypeAndCustomType()
     {
         // Arrange
         // Act

--- a/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/System/Serialization/DefaultSerializer/Serialize.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.UnitTests/System/Serialization/DefaultSerializer/Serialize.cs
@@ -3,7 +3,7 @@ namespace Expenso.Shared.Tests.UnitTests.System.Serialization.DefaultSerializer;
 internal sealed class Serialize : DefaultSerializerTestBase
 {
     [Test, TestCaseSource(sourceName: nameof(SerializedTestObjects))]
-    public void Serialize_Always_ShouldSerializeObject(object serializedObject)
+    public void Should_SerializeObject_Always(object serializedObject)
     {
         // Arrange
         // Act
@@ -14,7 +14,7 @@ internal sealed class Serialize : DefaultSerializerTestBase
     }
 
     [Test, TestCaseSource(sourceName: nameof(SerializedTestObjects))]
-    public void SerializeWithOptions_Always_ShouldSerializeObject(object serializedObject)
+    public void Should_SerializeObject_WithOptions(object serializedObject)
     {
         // Arrange
         // Act


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a `StatusTracker` to manage status-related properties for budget permission requests, enhancing the tracking of submission, confirmation, cancellation, and expiration dates.
  - Added a validation rule to ensure the expiration date is greater than the submission date.

- **Improvements**
  - Enhanced handling of time-sensitive operations by integrating a clock dependency in various services and command handlers.
  - Updated methods to utilize the new structure for accessing status-related information.

- **Bug Fixes**
  - Corrected status checks to reference the new `StatusTracker`, ensuring accurate filtering and processing of budget permission requests.

- **Tests**
  - Updated unit tests to reflect changes in status management and the introduction of the `StatusTracker`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->