### PR TITLE
Add period at the end of validation messages

### DIFF
--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/ApplicationSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/ApplicationSettingsValidator.cs
@@ -13,24 +13,24 @@ internal sealed class ApplicationSettingsValidator : ISettingsValidator<Applicat
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Application settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Application settings are required.");
 
             return errors;
         }
 
         if (settings.InstanceId is null || settings.InstanceId == Guid.Empty)
         {
-            errors.Add(key: nameof(settings.InstanceId), value: "Instance Id must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.InstanceId), value: "Instance Id must be provided and cannot be empty.");
         }
 
         if (string.IsNullOrEmpty(value: settings.Name))
         {
-            errors.Add(key: nameof(settings.Name), value: "Name must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Name), value: "Name must be provided and cannot be empty.");
         }
 
         if (string.IsNullOrEmpty(value: settings.Version))
         {
-            errors.Add(key: nameof(settings.Version), value: "Version must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Version), value: "Version must be provided and cannot be empty.");
         }
         else
         {
@@ -43,7 +43,7 @@ internal sealed class ApplicationSettingsValidator : ISettingsValidator<Applicat
             {
                 errors.Add(key: nameof(settings.Version),
                     value:
-                    $"Version mismatch. Expected: {assemblyVer.Major}.{assemblyVer.Minor}.{assemblyVer.Build}, but got: {settingsVer.Major}.{settingsVer.Minor}.{settingsVer.Build}");
+                    $"Version mismatch. Expected: [{assemblyVer.Major}.{assemblyVer.Minor}.{assemblyVer.Build}], but got: [{settingsVer.Major}.{settingsVer.Minor}.{settingsVer.Build}].");
             }
         }
 

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/AuthSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/AuthSettingsValidator.cs
@@ -13,14 +13,14 @@ internal sealed class AuthSettingsValidator : ISettingsValidator<AuthSettings>
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Auth settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Auth settings are required.");
 
             return errors;
         }
 
         if (!Enum.IsDefined(enumType: typeof(AuthServer), value: settings.AuthServer))
         {
-            errors.Add(key: nameof(settings.AuthServer), value: "AuthServer must be a valid value");
+            errors.Add(key: nameof(settings.AuthServer), value: "AuthServer must be a valid value.");
         }
 
         return errors;

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/EfCore/ConnectionParametersValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/EfCore/ConnectionParametersValidator.cs
@@ -14,72 +14,72 @@ internal sealed class ConnectionParametersValidator : ISettingsValidator<Connect
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Connection parameters settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Connection parameters settings are required.");
 
             return errors;
         }
 
         if (string.IsNullOrEmpty(value: settings.Host))
         {
-            errors.Add(key: nameof(settings.Host), value: "Host must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Host), value: "Host must be provided and cannot be empty.");
         }
         else if (!settings.Host.IsValidHost())
         {
-            errors.Add(key: nameof(settings.Host), value: "Host must be a valid DNS name or IP address");
+            errors.Add(key: nameof(settings.Host), value: "Host must be a valid DNS name or IP address.");
         }
 
         if (string.IsNullOrEmpty(value: settings?.Port))
         {
-            errors.Add(key: nameof(settings.Port), value: "Port must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Port), value: "Port must be provided and cannot be empty.");
         }
         else if (!int.TryParse(s: settings.Port, result: out int portNumber) || portNumber is < 1 or > 65535)
         {
-            errors.Add(key: nameof(settings.Port), value: "Port must be a valid integer between 1 and 65535");
+            errors.Add(key: nameof(settings.Port), value: "Port must be a valid integer between 1 and 65535.");
         }
 
         if (string.IsNullOrEmpty(value: settings?.DefaultDatabase))
         {
             errors.Add(key: nameof(settings.DefaultDatabase),
-                value: "DefaultDatabase must be provided and cannot be empty");
+                value: "DefaultDatabase must be provided and cannot be empty.");
         }
         else if (!settings.DefaultDatabase.IsAlphaNumericAndSpecialCharactersString(minLength: 1, maxLength: 100,
                      specialCharacters: "_-"))
         {
             errors.Add(key: nameof(settings.DefaultDatabase),
-                value: "DefaultDatabase must be an alphanumeric string between 1 and 100 characters");
+                value: "DefaultDatabase must be an alphanumeric string between 1 and 100 characters.");
         }
 
         if (string.IsNullOrEmpty(value: settings?.Database))
         {
-            errors.Add(key: nameof(settings.Database), value: "Database must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Database), value: "Database must be provided and cannot be empty.");
         }
         else if (!settings.Database.IsAlphaNumericAndSpecialCharactersString(minLength: 1, maxLength: 100,
                      specialCharacters: "_-"))
         {
             errors.Add(key: nameof(settings.Database),
-                value: "Database must be an alphanumeric string between 1 and 100 characters");
+                value: "Database must be an alphanumeric string between 1 and 100 characters.");
         }
 
         if (string.IsNullOrEmpty(value: settings?.User))
         {
-            errors.Add(key: nameof(settings.User), value: "User must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.User), value: "User must be provided and cannot be empty.");
         }
         else if (!settings.User.IsValidUsername())
         {
             errors.Add(key: nameof(settings.User),
                 value:
-                "User must be a valid alphanumeric string starting with a letter and between 3 and 30 characters");
+                "User must be a valid alphanumeric string starting with a letter and between 3 and 30 characters.");
         }
 
         if (string.IsNullOrEmpty(value: settings?.Password))
         {
-            errors.Add(key: nameof(settings.Password), value: "Password must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Password), value: "Password must be provided and cannot be empty.");
         }
         else if (!settings.Password.IsValidPassword(minLength: 8, maxLength: 30))
         {
             errors.Add(key: nameof(settings.Password),
                 value:
-                "Password must be between 8 and 30 characters, contain an upper and lower case letter, a digit, and a special character, with no spaces");
+                "Password must be between 8 and 30 characters, contain an upper and lower case letter, a digit, and a special character, with no spaces.");
         }
 
         return errors;

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/EfCore/EfCoreSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/EfCore/EfCoreSettingsValidator.cs
@@ -14,7 +14,7 @@ internal sealed class EfCoreSettingsValidator : ISettingsValidator<EfCoreSetting
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize().Pascalize(), value: "EfCore settings are required");
+            errors.Add(key: nameof(settings).Pascalize().Pascalize(), value: "EfCore settings are required.");
 
             return errors;
         }
@@ -22,7 +22,7 @@ internal sealed class EfCoreSettingsValidator : ISettingsValidator<EfCoreSetting
         if (settings.ConnectionParameters is null)
         {
             errors.Add(key: nameof(settings.ConnectionParameters),
-                value: "ConnectionParameters must be provided and cannot be null");
+                value: "ConnectionParameters must be provided and cannot be null.");
         }
         else
         {
@@ -31,17 +31,17 @@ internal sealed class EfCoreSettingsValidator : ISettingsValidator<EfCoreSetting
 
         if (settings.InMemory is null)
         {
-            errors.Add(key: nameof(settings.InMemory), value: "InMemory flag must be provided");
+            errors.Add(key: nameof(settings.InMemory), value: "InMemory flag must be provided.");
         }
 
         if (settings.UseMigration is null)
         {
-            errors.Add(key: nameof(settings.UseMigration), value: "UseMigration flag must be provided");
+            errors.Add(key: nameof(settings.UseMigration), value: "UseMigration flag must be provided.");
         }
 
         if (settings.UseSeeding is null)
         {
-            errors.Add(key: nameof(settings.UseSeeding), value: "UseSeeding flag must be provided");
+            errors.Add(key: nameof(settings.UseSeeding), value: "UseSeeding flag must be provided.");
         }
 
         return errors;

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/FileSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/FileSettingsValidator.cs
@@ -14,46 +14,46 @@ internal sealed class FilesSettingsValidator : ISettingsValidator<FilesSettings>
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "File settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "File settings are required.");
 
             return errors;
         }
 
         if (!Enum.IsDefined(enumType: typeof(FileStorageType), value: settings.StorageType))
         {
-            errors.Add(key: nameof(settings.StorageType), value: "StorageType must be a valid value");
+            errors.Add(key: nameof(settings.StorageType), value: "StorageType must be a valid value.");
         }
 
         if (!string.IsNullOrEmpty(value: settings.RootPath) && !settings.RootPath.IsValidRootPath())
         {
-            errors.Add(key: nameof(settings.RootPath), value: "RootPath must be a valid absolute path");
+            errors.Add(key: nameof(settings.RootPath), value: "RootPath must be a valid absolute path.");
         }
 
         if (string.IsNullOrEmpty(value: settings.ImportDirectory))
         {
             errors.Add(key: nameof(settings.ImportDirectory),
-                value: "ImportDirectory must be provided and cannot be empty");
+                value: "ImportDirectory must be provided and cannot be empty.");
         }
         else
         {
             if (!settings.ImportDirectory.IsValidRelativePath())
             {
                 errors.Add(key: nameof(settings.ImportDirectory),
-                    value: "ImportDirectory must be a valid relative path");
+                    value: "ImportDirectory must be a valid relative path.");
             }
         }
 
         if (string.IsNullOrEmpty(value: settings.ReportsDirectory))
         {
             errors.Add(key: nameof(settings.ReportsDirectory),
-                value: "ReportsDirectory must be provided and cannot be empty");
+                value: "ReportsDirectory must be provided and cannot be empty.");
         }
         else
         {
             if (!settings.ReportsDirectory.IsValidRelativePath())
             {
                 errors.Add(key: nameof(settings.ReportsDirectory),
-                    value: "ReportsDirectory must be a valid relative path");
+                    value: "ReportsDirectory must be a valid relative path.");
             }
         }
 

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/KeycloakSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/KeycloakSettingsValidator.cs
@@ -16,7 +16,7 @@ internal sealed class KeycloakSettingsValidator : ISettingsValidator<KeycloakSet
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Keycloak settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Keycloak settings are required.");
 
             return errors;
         }
@@ -24,34 +24,34 @@ internal sealed class KeycloakSettingsValidator : ISettingsValidator<KeycloakSet
         if (string.IsNullOrEmpty(value: settings.AuthServerUrl))
         {
             errors.Add(key: nameof(settings.AuthServerUrl),
-                value: "Authorization server URL must be provided and cannot be empty");
+                value: "Authorization server URL must be provided and cannot be empty.");
         }
         else
         {
             if (!settings.AuthServerUrl.IsValidUrl())
             {
                 errors.Add(key: nameof(settings.AuthServerUrl),
-                    value: "Authorization server URL must be a valid HTTP or HTTPS URL");
+                    value: "Authorization server URL must be a valid HTTP or HTTPS URL.");
             }
         }
 
         if (string.IsNullOrEmpty(value: settings.Realm))
         {
-            errors.Add(key: nameof(settings.Realm), value: "Realm must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Realm), value: "Realm must be provided and cannot be empty.");
         }
         else
         {
             if (!settings.Realm.IsAlphaNumericString(minLength: 5, maxLength: 50))
             {
                 errors.Add(key: nameof(settings.Realm),
-                    value: "Realm must be an alpha string with a length between 5 and 50 characters");
+                    value: "Realm must be an alpha string with a length between 5 and 50 characters.");
             }
         }
 
         if (string.IsNullOrEmpty(value: settings.Resource))
         {
             errors.Add(key: nameof(settings.Resource),
-                value: "Resource (client Id) must be provided and cannot be empty");
+                value: "Resource (client Id) must be provided and cannot be empty.");
         }
         else
         {
@@ -59,14 +59,14 @@ internal sealed class KeycloakSettingsValidator : ISettingsValidator<KeycloakSet
                     specialCharacters: "_.-"))
             {
                 errors.Add(key: nameof(settings.Resource),
-                    value: "Resource (client Id) must be an alpha string with a length between 5 and 100 characters");
+                    value: "Resource (client Id) must be an alpha string with a length between 5 and 100 characters.");
             }
         }
 
         if (string.IsNullOrEmpty(value: settings.SslRequired))
         {
             errors.Add(key: nameof(settings.SslRequired),
-                value: "SSL requirement must be specified and cannot be empty");
+                value: "SSL requirement must be specified and cannot be empty.");
         }
         else
         {
@@ -74,13 +74,13 @@ internal sealed class KeycloakSettingsValidator : ISettingsValidator<KeycloakSet
                     comparer: StringComparer.InvariantCultureIgnoreCase))
             {
                 errors.Add(key: nameof(settings.SslRequired),
-                    value: "SSL requirement must be one of the predefined values");
+                    value: "SSL requirement must be one of the predefined values.");
             }
         }
 
         if (settings.VerifyTokenAudience == null)
         {
-            errors.Add(key: nameof(settings.VerifyTokenAudience), value: "VerifyTokenAudience must be specified");
+            errors.Add(key: nameof(settings.VerifyTokenAudience), value: "VerifyTokenAudience must be specified.");
         }
 
         /* ReSharper disable once ConditionIsAlwaysTrueOrFalseAccordingToNullableAPIContract
@@ -88,7 +88,7 @@ internal sealed class KeycloakSettingsValidator : ISettingsValidator<KeycloakSet
            it for sure can be null in some cases */
         if (settings.Credentials == null)
         {
-            errors.Add(key: nameof(settings.Credentials), value: "Client secret must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Credentials), value: "Client secret must be provided and cannot be empty.");
 
             return errors;
         }
@@ -96,14 +96,14 @@ internal sealed class KeycloakSettingsValidator : ISettingsValidator<KeycloakSet
         if (string.IsNullOrEmpty(value: settings.Credentials.Secret))
         {
             errors.Add(key: nameof(settings.Credentials.Secret),
-                value: "Client secret must be provided and cannot be empty");
+                value: "Client secret must be provided and cannot be empty.");
         }
         else
         {
             if (!Guid.TryParse(input: settings.Credentials.Secret, result: out Guid _))
             {
                 errors.Add(key: nameof(settings.Credentials.Secret),
-                    value: "Client secret must be a valid GUID format");
+                    value: "Client secret must be a valid GUID format.");
             }
         }
 

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/EmailNotificationSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/EmailNotificationSettingsValidator.cs
@@ -15,14 +15,14 @@ internal sealed class EmailNotificationSettingsValidator : ISettingsValidator<Em
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Email notification settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Email notification settings are required.");
 
             return errors;
         }
 
         if (settings.Enabled is null)
         {
-            errors.Add(key: nameof(settings.Enabled), value: "Email enabled flag must be provided");
+            errors.Add(key: nameof(settings.Enabled), value: "Email enabled flag must be provided.");
 
             return errors;
         }
@@ -34,26 +34,26 @@ internal sealed class EmailNotificationSettingsValidator : ISettingsValidator<Em
 
         if (string.IsNullOrEmpty(value: settings.From))
         {
-            errors.Add(key: nameof(settings.From), value: "Email 'From' address must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.From), value: "Email 'From' address must be provided and cannot be empty.");
         }
         else if (!settings.From.IsValidEmail())
         {
-            errors.Add(key: nameof(settings.From), value: "Email 'From' address must be a valid email address");
+            errors.Add(key: nameof(settings.From), value: "Email 'From' address must be a valid email address.");
         }
 
         if (string.IsNullOrEmpty(value: settings.ReplyTo))
         {
             errors.Add(key: nameof(settings.ReplyTo),
-                value: "Email 'ReplyTo' address must be provided and cannot be empty");
+                value: "Email 'ReplyTo' address must be provided and cannot be empty.");
         }
         else if (!settings.ReplyTo.IsValidEmail())
         {
-            errors.Add(key: nameof(settings.ReplyTo), value: "Email 'ReplyTo' address must be a valid email address");
+            errors.Add(key: nameof(settings.ReplyTo), value: "Email 'ReplyTo' address must be a valid email address.");
         }
 
         if (settings.Smtp is null)
         {
-            errors.Add(key: nameof(settings.Smtp), value: "Smtp must be provided and cannot be null");
+            errors.Add(key: nameof(settings.Smtp), value: "Smtp must be provided and cannot be null.");
         }
         else
         {

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/InAppNotificationSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/InAppNotificationSettingsValidator.cs
@@ -13,14 +13,14 @@ internal sealed class InAppNotificationSettingsValidator : ISettingsValidator<In
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "In-app notification settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "In-app notification settings are required.");
 
             return errors;
         }
 
         if (settings.Enabled is null)
         {
-            errors.Add(key: nameof(settings.Enabled), value: "In-app enabled flag must be provided");
+            errors.Add(key: nameof(settings.Enabled), value: "In-app enabled flag must be provided.");
         }
 
         return errors;

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/NotificationsSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/NotificationsSettingsValidator.cs
@@ -14,14 +14,14 @@ internal sealed class NotificationSettingsValidator : ISettingsValidator<Notific
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Notification settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Notification settings are required.");
 
             return errors;
         }
 
         if (settings.Enabled is null)
         {
-            errors.Add(key: nameof(settings.Enabled), value: "Enabled flag must be provided");
+            errors.Add(key: nameof(settings.Enabled), value: "Enabled flag must be provided.");
 
             return errors;
         }
@@ -33,7 +33,7 @@ internal sealed class NotificationSettingsValidator : ISettingsValidator<Notific
 
         if (settings.Email is null)
         {
-            errors.Add(key: nameof(settings.Email), value: "Email notification settings must be provided");
+            errors.Add(key: nameof(settings.Email), value: "Email notification settings must be provided.");
         }
         else
         {
@@ -42,7 +42,7 @@ internal sealed class NotificationSettingsValidator : ISettingsValidator<Notific
 
         if (settings.InApp is null)
         {
-            errors.Add(key: nameof(settings.InApp), value: "In-app notification settings must be provided");
+            errors.Add(key: nameof(settings.InApp), value: "In-app notification settings must be provided.");
         }
         else
         {
@@ -51,7 +51,7 @@ internal sealed class NotificationSettingsValidator : ISettingsValidator<Notific
 
         if (settings.Push is null)
         {
-            errors.Add(key: nameof(settings.Push), value: "Push notification settings must be provided");
+            errors.Add(key: nameof(settings.Push), value: "Push notification settings must be provided.");
         }
         else
         {

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/PushNotificationSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/PushNotificationSettingsValidator.cs
@@ -13,14 +13,14 @@ internal sealed class PushNotificationSettingsValidator : ISettingsValidator<Pus
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Push notification settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Push notification settings are required.");
 
             return errors;
         }
 
         if (settings.Enabled is null)
         {
-            errors.Add(key: nameof(settings.Enabled), value: "Push enabled flag must be provided");
+            errors.Add(key: nameof(settings.Enabled), value: "Push enabled flag must be provided.");
         }
 
         return errors;

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/SmtpSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/Notifications/SmtpSettingsValidator.cs
@@ -14,44 +14,44 @@ internal sealed class SmtpSettingsValidator : ISettingsValidator<SmtpSettings>
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "SMTP settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "SMTP settings are required.");
 
             return errors;
         }
 
         if (string.IsNullOrEmpty(value: settings.Host))
         {
-            errors.Add(key: nameof(settings.Host), value: "SMTP host must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Host), value: "SMTP host must be provided and cannot be empty.");
         }
         else if (!settings.Host.IsValidHost())
         {
-            errors.Add(key: nameof(settings.Host), value: "SMTP host must be a valid DNS name, IPv4, or IPv6 address");
+            errors.Add(key: nameof(settings.Host), value: "SMTP host must be a valid DNS name, IPv4, or IPv6 address.");
         }
 
         if (settings.Port <= 0 || !settings.Port.IsValidPort())
         {
-            errors.Add(key: nameof(settings.Port), value: "SMTP port must be a valid integer between 1 and 65535");
+            errors.Add(key: nameof(settings.Port), value: "SMTP port must be a valid integer between 1 and 65535.");
         }
 
         if (string.IsNullOrEmpty(value: settings.Username))
         {
-            errors.Add(key: nameof(settings.Username), value: "SMTP username must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Username), value: "SMTP username must be provided and cannot be empty.");
         }
         else if (!settings.Username.IsValidUsername())
         {
             errors.Add(key: nameof(settings.Username),
-                value: "SMTP username must be between 3 and 30 characters long and start with a letter");
+                value: "SMTP username must be between 3 and 30 characters long and start with a letter.");
         }
 
         if (string.IsNullOrEmpty(value: settings.Password))
         {
-            errors.Add(key: nameof(settings.Password), value: "SMTP password must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Password), value: "SMTP password must be provided and cannot be empty.");
         }
         else if (!settings.Password.IsValidPassword(minLength: 8, maxLength: 20))
         {
             errors.Add(key: nameof(settings.Password),
                 value:
-                "SMTP password must be between 8 and 20 characters long, with at least one uppercase letter, one lowercase letter, one digit, and one special character");
+                "SMTP password must be between 8 and 20 characters long, with at least one uppercase letter, one lowercase letter, one digit, and one special character.");
         }
 
         return errors;

--- a/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/OtlpSettingsValidator.cs
+++ b/src/Api/Expenso.Api/Configuration/Settings/Services/Validators/OtlpSettingsValidator.cs
@@ -14,33 +14,33 @@ internal sealed class OtlpSettingsValidator : ISettingsValidator<OtlpSettings>
 
         if (settings is null)
         {
-            errors.Add(key: nameof(settings).Pascalize(), value: "Otlp settings are required");
+            errors.Add(key: nameof(settings).Pascalize(), value: "Otlp settings are required.");
 
             return errors;
         }
 
         if (string.IsNullOrEmpty(value: settings.ServiceName))
         {
-            errors.Add(key: nameof(settings.ServiceName), value: "Service name must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.ServiceName), value: "Service name must be provided and cannot be empty.");
         }
         else
         {
             if (!settings.ServiceName.IsAlphaNumericAndSpecialCharactersString(specialCharacters: "_.-"))
             {
                 errors.Add(key: nameof(settings.ServiceName),
-                    value: "Service name can only contain alphanumeric characters and special characters");
+                    value: "Service name can only contain alphanumeric characters and special characters.");
             }
         }
 
         if (string.IsNullOrEmpty(value: settings.Endpoint))
         {
-            errors.Add(key: nameof(settings.Endpoint), value: "Endpoint must be provided and cannot be empty");
+            errors.Add(key: nameof(settings.Endpoint), value: "Endpoint must be provided and cannot be empty.");
         }
         else
         {
             if (!settings.Endpoint.IsValidUrl())
             {
-                errors.Add(key: nameof(settings.Endpoint), value: "Endpoint must be a valid URL");
+                errors.Add(key: nameof(settings.Endpoint), value: "Endpoint must be a valid URL.");
             }
         }
 

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/ApplicationSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/ApplicationSettingsValidator/Validate.cs
@@ -11,7 +11,7 @@ internal sealed class Validate : ApplicationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Application settings are required";
+        const string expectedValidationMessage = "Application settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -30,7 +30,7 @@ internal sealed class Validate : ApplicationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Instance Id must be provided and cannot be empty";
+        const string expectedValidationMessage = "Instance Id must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_applicationSettings.InstanceId)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -49,7 +49,7 @@ internal sealed class Validate : ApplicationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Instance Id must be provided and cannot be empty";
+        const string expectedValidationMessage = "Instance Id must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_applicationSettings.InstanceId)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -68,7 +68,7 @@ internal sealed class Validate : ApplicationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Name must be provided and cannot be empty";
+        const string expectedValidationMessage = "Name must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_applicationSettings.Name)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -87,7 +87,7 @@ internal sealed class Validate : ApplicationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Version must be provided and cannot be empty";
+        const string expectedValidationMessage = "Version must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_applicationSettings.Version)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -110,7 +110,7 @@ internal sealed class Validate : ApplicationSettingsValidatorTestBase
         string[] assemblyVersionParts = assemblyVersion.Split(separator: '.');
 
         string expectedValidationMessage =
-            $"Version mismatch. Expected: {assemblyVersionParts[0]}.{assemblyVersionParts[1]}.{assemblyVersionParts[2]}, but got: 2.0.0";
+            $"Version mismatch. Expected: [{assemblyVersionParts[0]}.{assemblyVersionParts[1]}.{assemblyVersionParts[2]}], but got: [2.0.0].";
 
         string error = validationResult[key: nameof(_applicationSettings.Version)];
         error.Should().Be(expected: expectedValidationMessage);

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/AuthSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/AuthSettingsValidator/Validate.cs
@@ -13,7 +13,7 @@ internal sealed class Validate : AuthSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Auth settings are required";
+        const string expectedValidationMessage = "Auth settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -32,7 +32,7 @@ internal sealed class Validate : AuthSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "AuthServer must be a valid value";
+        const string expectedValidationMessage = "AuthServer must be a valid value.";
         string error = validationResult[key: nameof(_authSettings.AuthServer)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/EfCore/ConnectionParametersValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/EfCore/ConnectionParametersValidator/Validate.cs
@@ -11,7 +11,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Connection parameters settings are required";
+        const string expectedValidationMessage = "Connection parameters settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -30,7 +30,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Host must be provided and cannot be empty";
+        const string expectedValidationMessage = "Host must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_connectionParameters.Host)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -49,7 +49,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Host must be a valid DNS name or IP address";
+        const string expectedValidationMessage = "Host must be a valid DNS name or IP address.";
         string error = validationResult[key: nameof(_connectionParameters.Host)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -68,7 +68,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Port must be provided and cannot be empty";
+        const string expectedValidationMessage = "Port must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_connectionParameters.Port)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -87,7 +87,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Port must be a valid integer between 1 and 65535";
+        const string expectedValidationMessage = "Port must be a valid integer between 1 and 65535.";
         string error = validationResult[key: nameof(_connectionParameters.Port)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -107,7 +107,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "DefaultDatabase must be provided and cannot be empty";
+        const string expectedValidationMessage = "DefaultDatabase must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_connectionParameters.DefaultDatabase)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -128,7 +128,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "DefaultDatabase must be an alphanumeric string between 1 and 100 characters";
+            "DefaultDatabase must be an alphanumeric string between 1 and 100 characters.";
 
         string error = validationResult[key: nameof(_connectionParameters.DefaultDatabase)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -148,7 +148,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Database must be provided and cannot be empty";
+        const string expectedValidationMessage = "Database must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_connectionParameters.Database)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -167,7 +167,9 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Database must be an alphanumeric string between 1 and 100 characters";
+
+        const string expectedValidationMessage =
+            "Database must be an alphanumeric string between 1 and 100 characters.";
         string error = validationResult[key: nameof(_connectionParameters.Database)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -186,7 +188,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "User must be provided and cannot be empty";
+        const string expectedValidationMessage = "User must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_connectionParameters.User)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -207,7 +209,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "User must be a valid alphanumeric string starting with a letter and between 3 and 30 characters";
+            "User must be a valid alphanumeric string starting with a letter and between 3 and 30 characters.";
 
         string error = validationResult[key: nameof(_connectionParameters.User)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -227,7 +229,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Password must be provided and cannot be empty";
+        const string expectedValidationMessage = "Password must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_connectionParameters.Password)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -248,7 +250,7 @@ internal sealed class Validate : ConnectionParametersValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "Password must be between 8 and 30 characters, contain an upper and lower case letter, a digit, and a special character, with no spaces";
+            "Password must be between 8 and 30 characters, contain an upper and lower case letter, a digit, and a special character, with no spaces.";
 
         string error = validationResult[key: nameof(_connectionParameters.Password)];
         error.Should().Be(expected: expectedValidationMessage);

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/EfCore/EfCoreValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/EfCore/EfCoreValidator/Validate.cs
@@ -13,7 +13,7 @@ internal sealed class Validate : EfCoreSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "EfCore settings are required";
+        const string expectedValidationMessage = "EfCore settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -32,7 +32,7 @@ internal sealed class Validate : EfCoreSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "ConnectionParameters must be provided and cannot be null";
+        const string expectedValidationMessage = "ConnectionParameters must be provided and cannot be null.";
         string error = validationResult[key: nameof(_efCoreSettings.ConnectionParameters)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -54,7 +54,7 @@ internal sealed class Validate : EfCoreSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Host must be provided and cannot be empty";
+        const string expectedValidationMessage = "Host must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_efCoreSettings.ConnectionParameters.Host)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -73,7 +73,7 @@ internal sealed class Validate : EfCoreSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "InMemory flag must be provided";
+        const string expectedValidationMessage = "InMemory flag must be provided.";
         string error = validationResult[key: nameof(_efCoreSettings.InMemory)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -92,7 +92,7 @@ internal sealed class Validate : EfCoreSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "UseMigration flag must be provided";
+        const string expectedValidationMessage = "UseMigration flag must be provided.";
         string error = validationResult[key: nameof(_efCoreSettings.UseMigration)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -111,7 +111,7 @@ internal sealed class Validate : EfCoreSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "UseSeeding flag must be provided";
+        const string expectedValidationMessage = "UseSeeding flag must be provided.";
         string error = validationResult[key: nameof(_efCoreSettings.UseSeeding)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/FileSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/FileSettingsValidator/Validate.cs
@@ -13,7 +13,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "File settings are required";
+        const string expectedValidationMessage = "File settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -32,7 +32,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "StorageType must be a valid value";
+        const string expectedValidationMessage = "StorageType must be a valid value.";
         string error = validationResult[key: nameof(_filesSettings.StorageType)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -51,7 +51,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "RootPath must be a valid absolute path";
+        const string expectedValidationMessage = "RootPath must be a valid absolute path.";
         string error = validationResult[key: nameof(_filesSettings.RootPath)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -71,7 +71,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "ImportDirectory must be provided and cannot be empty";
+        const string expectedValidationMessage = "ImportDirectory must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_filesSettings.ImportDirectory)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -90,7 +90,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "ImportDirectory must be a valid relative path";
+        const string expectedValidationMessage = "ImportDirectory must be a valid relative path.";
         string error = validationResult[key: nameof(_filesSettings.ImportDirectory)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -110,7 +110,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "ReportsDirectory must be provided and cannot be empty";
+        const string expectedValidationMessage = "ReportsDirectory must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_filesSettings.ReportsDirectory)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -129,7 +129,7 @@ internal sealed class Validate : FileSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "ReportsDirectory must be a valid relative path";
+        const string expectedValidationMessage = "ReportsDirectory must be a valid relative path.";
         string error = validationResult[key: nameof(_filesSettings.ReportsDirectory)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/KeycloakSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/KeycloakSettingsValidator/Validate.cs
@@ -11,7 +11,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Keycloak settings are required";
+        const string expectedValidationMessage = "Keycloak settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -27,7 +27,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Authorization server URL must be provided and cannot be empty";
+        const string expectedValidationMessage = "Authorization server URL must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_keycloakSettings.AuthServerUrl)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -43,7 +43,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Authorization server URL must be a valid HTTP or HTTPS URL";
+        const string expectedValidationMessage = "Authorization server URL must be a valid HTTP or HTTPS URL.";
         string error = validationResult[key: nameof(_keycloakSettings.AuthServerUrl)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -59,7 +59,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Realm must be provided and cannot be empty";
+        const string expectedValidationMessage = "Realm must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_keycloakSettings.Realm)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -77,7 +77,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "Realm must be an alpha string with a length between 5 and 50 characters";
+            "Realm must be an alpha string with a length between 5 and 50 characters.";
 
         string error = validationResult[key: nameof(_keycloakSettings.Realm)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -94,7 +94,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Resource (client Id) must be provided and cannot be empty";
+        const string expectedValidationMessage = "Resource (client Id) must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_keycloakSettings.Resource)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -112,7 +112,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "Resource (client Id) must be an alpha string with a length between 5 and 100 characters";
+            "Resource (client Id) must be an alpha string with a length between 5 and 100 characters.";
 
         string error = validationResult[key: nameof(_keycloakSettings.Resource)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -129,7 +129,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SSL requirement must be specified and cannot be empty";
+        const string expectedValidationMessage = "SSL requirement must be specified and cannot be empty.";
         string error = validationResult[key: nameof(_keycloakSettings.SslRequired)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -145,7 +145,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SSL requirement must be one of the predefined values";
+        const string expectedValidationMessage = "SSL requirement must be one of the predefined values.";
         string error = validationResult[key: nameof(_keycloakSettings.SslRequired)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -161,7 +161,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "VerifyTokenAudience must be specified";
+        const string expectedValidationMessage = "VerifyTokenAudience must be specified.";
         string error = validationResult[key: nameof(_keycloakSettings.VerifyTokenAudience)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -177,7 +177,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Client secret must be provided and cannot be empty";
+        const string expectedValidationMessage = "Client secret must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_keycloakSettings.Credentials)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -193,7 +193,7 @@ internal sealed class Validate : KeycloakSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Client secret must be a valid GUID format";
+        const string expectedValidationMessage = "Client secret must be a valid GUID format.";
         string error = validationResult[key: nameof(_keycloakSettings.Credentials.Secret)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/EmailSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/EmailSettingsValidator/Validate.cs
@@ -13,7 +13,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email notification settings are required";
+        const string expectedValidationMessage = "Email notification settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -32,7 +32,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email enabled flag must be provided";
+        const string expectedValidationMessage = "Email enabled flag must be provided.";
         string error = validationResult[key: nameof(_emailNotificationSettings.Enabled)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -67,7 +67,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email 'From' address must be provided and cannot be empty";
+        const string expectedValidationMessage = "Email 'From' address must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_emailNotificationSettings.From)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -86,7 +86,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email 'From' address must be a valid email address";
+        const string expectedValidationMessage = "Email 'From' address must be a valid email address.";
         string error = validationResult[key: nameof(_emailNotificationSettings.From)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -105,7 +105,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email 'ReplyTo' address must be provided and cannot be empty";
+        const string expectedValidationMessage = "Email 'ReplyTo' address must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_emailNotificationSettings.ReplyTo)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -124,7 +124,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email 'ReplyTo' address must be a valid email address";
+        const string expectedValidationMessage = "Email 'ReplyTo' address must be a valid email address.";
         string error = validationResult[key: nameof(_emailNotificationSettings.ReplyTo)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -143,7 +143,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Smtp must be provided and cannot be null";
+        const string expectedValidationMessage = "Smtp must be provided and cannot be null.";
         string error = validationResult[key: nameof(_emailNotificationSettings.Smtp)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -165,7 +165,7 @@ internal sealed class Validate : EmailNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP host must be provided and cannot be empty";
+        const string expectedValidationMessage = "SMTP host must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_emailNotificationSettings.Smtp.Host)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/InAppSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/InAppSettingsValidator/Validate.cs
@@ -15,7 +15,7 @@ internal sealed class Validate : InAppNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "In-app notification settings are required";
+        const string expectedValidationMessage = "In-app notification settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -31,7 +31,7 @@ internal sealed class Validate : InAppNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "In-app enabled flag must be provided";
+        const string expectedValidationMessage = "In-app enabled flag must be provided.";
         string error = validationResult[key: nameof(_inAppNotificationSettings.Enabled)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/NotificationsSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/NotificationsSettingsValidator/Validate.cs
@@ -14,7 +14,7 @@ internal sealed class Validate : NotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Notification settings are required";
+        const string expectedValidationMessage = "Notification settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -33,7 +33,7 @@ internal sealed class Validate : NotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Enabled flag must be provided";
+        const string expectedValidationMessage = "Enabled flag must be provided.";
         string error = validationResult[key: nameof(_notificationSettings.Enabled)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -68,7 +68,7 @@ internal sealed class Validate : NotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email notification settings must be provided";
+        const string expectedValidationMessage = "Email notification settings must be provided.";
         string error = validationResult[key: nameof(_notificationSettings.Email)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -90,7 +90,7 @@ internal sealed class Validate : NotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Email 'From' address must be provided and cannot be empty";
+        const string expectedValidationMessage = "Email 'From' address must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_notificationSettings.Email.From)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -109,7 +109,7 @@ internal sealed class Validate : NotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "In-app notification settings must be provided";
+        const string expectedValidationMessage = "In-app notification settings must be provided.";
         string error = validationResult[key: nameof(_notificationSettings.InApp)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -128,7 +128,7 @@ internal sealed class Validate : NotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Push notification settings must be provided";
+        const string expectedValidationMessage = "Push notification settings must be provided.";
         string error = validationResult[key: nameof(_notificationSettings.Push)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/PushSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/PushSettingsValidator/Validate.cs
@@ -15,7 +15,7 @@ internal sealed class Validate : PushNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Push notification settings are required";
+        const string expectedValidationMessage = "Push notification settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -31,7 +31,7 @@ internal sealed class Validate : PushNotificationSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Push enabled flag must be provided";
+        const string expectedValidationMessage = "Push enabled flag must be provided.";
         string error = validationResult[key: nameof(_pushNotificationSettings.Enabled)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/SmtpSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/Notifications/SmtpSettingsValidator/Validate.cs
@@ -13,7 +13,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP settings are required";
+        const string expectedValidationMessage = "SMTP settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -32,7 +32,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP host must be provided and cannot be empty";
+        const string expectedValidationMessage = "SMTP host must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_smtpSettings.Host)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -51,7 +51,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP host must be a valid DNS name, IPv4, or IPv6 address";
+        const string expectedValidationMessage = "SMTP host must be a valid DNS name, IPv4, or IPv6 address.";
         string error = validationResult[key: nameof(_smtpSettings.Host)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -70,7 +70,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP port must be a valid integer between 1 and 65535";
+        const string expectedValidationMessage = "SMTP port must be a valid integer between 1 and 65535.";
         string error = validationResult[key: nameof(_smtpSettings.Port)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -89,7 +89,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP username must be provided and cannot be empty";
+        const string expectedValidationMessage = "SMTP username must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_smtpSettings.Username)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -110,7 +110,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "SMTP username must be between 3 and 30 characters long and start with a letter";
+            "SMTP username must be between 3 and 30 characters long and start with a letter.";
 
         string error = validationResult[key: nameof(_smtpSettings.Username)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -130,7 +130,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "SMTP password must be provided and cannot be empty";
+        const string expectedValidationMessage = "SMTP password must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_smtpSettings.Password)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -151,7 +151,7 @@ internal sealed class Validate : SmtpSettingsValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "SMTP password must be between 8 and 20 characters long, with at least one uppercase letter, one lowercase letter, one digit, and one special character";
+            "SMTP password must be between 8 and 20 characters long, with at least one uppercase letter, one lowercase letter, one digit, and one special character.";
 
         string error = validationResult[key: nameof(_smtpSettings.Password)];
         error.Should().Be(expected: expectedValidationMessage);

--- a/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/OtlpSettingsValidator/Validate.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.UnitTests/Configuration/Settings/Services/Validators/OtlpSettingsValidator/Validate.cs
@@ -11,7 +11,7 @@ internal sealed class Validate : OtlpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Otlp settings are required";
+        const string expectedValidationMessage = "Otlp settings are required.";
         string error = validationResult[key: "Settings"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -30,7 +30,7 @@ internal sealed class Validate : OtlpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Service name must be provided and cannot be empty";
+        const string expectedValidationMessage = "Service name must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_otlpSettings.ServiceName)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -51,7 +51,7 @@ internal sealed class Validate : OtlpSettingsValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "Service name can only contain alphanumeric characters and special characters";
+            "Service name can only contain alphanumeric characters and special characters.";
 
         string error = validationResult[key: nameof(_otlpSettings.ServiceName)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -71,7 +71,7 @@ internal sealed class Validate : OtlpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Endpoint must be provided and cannot be empty";
+        const string expectedValidationMessage = "Endpoint must be provided and cannot be empty.";
         string error = validationResult[key: nameof(_otlpSettings.Endpoint)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -90,7 +90,7 @@ internal sealed class Validate : OtlpSettingsValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Endpoint must be a valid URL";
+        const string expectedValidationMessage = "Endpoint must be a valid URL.";
         string error = validationResult[key: nameof(_otlpSettings.Endpoint)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/Communication/Expenso.Communication.Core/Application/Notifications/Write/Commands/SendNotification/SendNotificationCommandValidator.cs
+++ b/src/Communication/Expenso.Communication.Core/Application/Notifications/Write/Commands/SendNotification/SendNotificationCommandValidator.cs
@@ -10,7 +10,7 @@ internal sealed class SendNotificationCommandValidator : ICommandValidator<SendN
 
         if (command.SendNotificationRequest is null)
         {
-            errors.Add(key: nameof(command.SendNotificationRequest), value: "Send notification request is required");
+            errors.Add(key: nameof(command.SendNotificationRequest), value: "Send notification request is required.");
 
             return errors;
         }
@@ -18,7 +18,7 @@ internal sealed class SendNotificationCommandValidator : ICommandValidator<SendN
         if (command.SendNotificationRequest?.NotificationContext is null)
         {
             errors.Add(key: nameof(command.SendNotificationRequest.NotificationContext),
-                value: "Notification context is required");
+                value: "Notification context is required.");
 
             return errors;
         }
@@ -26,7 +26,7 @@ internal sealed class SendNotificationCommandValidator : ICommandValidator<SendN
         if (command.SendNotificationRequest?.NotificationType is null)
         {
             errors.Add(key: nameof(command.SendNotificationRequest.NotificationType),
-                value: "Notification type is required");
+                value: "Notification type is required.");
 
             return errors;
         }
@@ -35,24 +35,24 @@ internal sealed class SendNotificationCommandValidator : ICommandValidator<SendN
             command.SendNotificationRequest?.Content.Length > 2500)
         {
             errors.Add(key: nameof(command.SendNotificationRequest.Content),
-                value: "Content is required and must be less than 2500 characters");
+                value: "Content is required and must be less than 2500 characters.");
         }
 
         if (string.IsNullOrEmpty(value: command.SendNotificationRequest?.NotificationContext?.To))
         {
-            errors.Add(key: nameof(command.SendNotificationRequest.NotificationContext.To), value: "To is required");
+            errors.Add(key: nameof(command.SendNotificationRequest.NotificationContext.To), value: "To is required.");
         }
 
         if (string.IsNullOrEmpty(value: command.SendNotificationRequest?.NotificationContext?.From))
         {
             errors.Add(key: nameof(command.SendNotificationRequest.NotificationContext.From),
-                value: "From is required");
+                value: "From is required.");
         }
 
         if (command.SendNotificationRequest?.NotificationType is { Push: false, Email: false, InApp: false })
         {
             errors.Add(key: nameof(command.SendNotificationRequest.NotificationType),
-                value: "At least one notification type is required");
+                value: "At least one notification type is required.");
         }
 
         return errors;

--- a/src/Communication/Tests/Expenso.Communication.Tests.UnitTests/Application/Notifications/Write/Commands/SendNotification/SendNotificationCommandValidator/Validate.cs
+++ b/src/Communication/Tests/Expenso.Communication.Tests.UnitTests/Application/Notifications/Write/Commands/SendNotification/SendNotificationCommandValidator/Validate.cs
@@ -23,7 +23,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest)]
             .Should()
-            .Be(expected: "Send notification request is required");
+            .Be(expected: "Send notification request is required.");
     }
 
     [Test]
@@ -44,7 +44,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.NotificationContext)]
             .Should()
-            .Be(expected: "Notification context is required");
+            .Be(expected: "Notification context is required.");
     }
 
     [Test]
@@ -64,7 +64,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.NotificationType)]
             .Should()
-            .Be(expected: "Notification type is required");
+            .Be(expected: "Notification type is required.");
     }
 
     [Test]
@@ -85,7 +85,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.NotificationContext.To)]
             .Should()
-            .Be(expected: "To is required");
+            .Be(expected: "To is required.");
     }
 
     [Test]
@@ -106,7 +106,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.NotificationContext.From)]
             .Should()
-            .Be(expected: "From is required");
+            .Be(expected: "From is required.");
     }
 
     [Test]
@@ -127,7 +127,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.Content)]
             .Should()
-            .Be(expected: "Content is required and must be less than 2500 characters");
+            .Be(expected: "Content is required and must be less than 2500 characters.");
     }
 
     [Test]
@@ -149,7 +149,7 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.Content)]
             .Should()
-            .Be(expected: "Content is required and must be less than 2500 characters");
+            .Be(expected: "Content is required and must be less than 2500 characters.");
     }
 
     [Test]
@@ -170,6 +170,6 @@ internal sealed class Validate : SendNotificationCommandValidatorTestBase
 
         result[key: nameof(command.SendNotificationRequest.NotificationType)]
             .Should()
-            .Be(expected: "At least one notification type is required");
+            .Be(expected: "At least one notification type is required.");
     }
 }

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/Jobs/Write/RegisterJob/RegisterJobEntryCommandValidator.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/Jobs/Write/RegisterJob/RegisterJobEntryCommandValidator.cs
@@ -27,20 +27,20 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
 
         if (command is null)
         {
-            errors.Add(key: nameof(command).Pascalize(), value: "Command is required");
+            errors.Add(key: nameof(command).Pascalize(), value: "Command is required.");
 
             return errors;
         }
 
         if (command.RegisterJobEntryRequest is null)
         {
-            errors.Add(key: nameof(command.RegisterJobEntryRequest), value: "Register job entry request is required");
+            errors.Add(key: nameof(command.RegisterJobEntryRequest), value: "Register job entry request is required.");
         }
 
         if (command.RegisterJobEntryRequest?.MaxRetries is not null && command.RegisterJobEntryRequest?.MaxRetries <= 0)
         {
             errors.Add(key: nameof(command.RegisterJobEntryRequest.MaxRetries),
-                value: "MaxRetries must be a positive value");
+                value: "MaxRetries must be a positive value.");
         }
 
         if (command.RegisterJobEntryRequest?.Interval is null && command.RegisterJobEntryRequest?.RunAt is null)
@@ -48,7 +48,7 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
             errors.Add(
                 key:
                 $"{nameof(command.RegisterJobEntryRequest.Interval)}|{nameof(command.RegisterJobEntryRequest.RunAt)}",
-                value: "At least one value must be provided: Interval for periodic jobs or RunAt for single run jobs");
+                value: "At least one value must be provided: Interval for periodic jobs or RunAt for single run jobs.");
         }
 
         if (command.RegisterJobEntryRequest?.Interval is not null && command.RegisterJobEntryRequest?.RunAt is not null)
@@ -56,7 +56,7 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
             errors.Add(
                 key:
                 $"{nameof(command.RegisterJobEntryRequest.Interval)}|{nameof(command.RegisterJobEntryRequest.RunAt)}",
-                value: "RunAt and Interval cannot be used together");
+                value: "RunAt and Interval cannot be used together.");
         }
 
         if (command.RegisterJobEntryRequest?.Interval is not null)
@@ -81,7 +81,7 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
         {
             errors.Add(key: nameof(command.RegisterJobEntryRequest.RunAt),
                 value:
-                $"RunAt must be greater than current time. Provided: {command.RegisterJobEntryRequest.RunAt}. Current: {_clock.UtcNow}");
+                $"RunAt must be greater than current time. Provided: {command.RegisterJobEntryRequest.RunAt}. Current: {_clock.UtcNow}.");
         }
 
         ICollection<RegisterJobEntryRequest_JobEntryTrigger>? jobEntryTriggers =
@@ -90,7 +90,7 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
         if (jobEntryTriggers is null || jobEntryTriggers.Count is 0)
         {
             errors.Add(key: nameof(command.RegisterJobEntryRequest.JobEntryTriggers),
-                value: "Job entry triggers are required");
+                value: "Job entry triggers are required.");
         }
 
         if (errors.Count > 0)
@@ -102,12 +102,12 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
         {
             if (string.IsNullOrEmpty(value: jobEntryTrigger.EventType))
             {
-                errors.Add(key: nameof(jobEntryTrigger.EventType), value: "Event type is required");
+                errors.Add(key: nameof(jobEntryTrigger.EventType), value: "Event type is required.");
             }
 
             if (string.IsNullOrEmpty(value: jobEntryTrigger.EventData))
             {
-                errors.Add(key: nameof(jobEntryTrigger.EventData), value: "Event data is required");
+                errors.Add(key: nameof(jobEntryTrigger.EventData), value: "Event data is required.");
             }
 
             if (jobEntryTrigger.EventType is not null && _serializer.Deserialize(value: jobEntryTrigger.EventData!,
@@ -115,7 +115,7 @@ internal sealed class RegisterJobEntryCommandValidator : ICommandValidator<Regis
                     settings: DefaultSerializerOptions.DefaultSettings) is null)
             {
                 errors.Add(key: $"{nameof(jobEntryTrigger.EventType)}|{nameof(jobEntryTrigger.EventData)}",
-                    value: "EventData must be serializable to provided EventType");
+                    value: "EventData must be serializable to provided EventType.");
             }
         }
 

--- a/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Application/Jobs/Write/RegisterJob/RegisterJobEntryCommandValidator/Validate.cs
+++ b/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Application/Jobs/Write/RegisterJob/RegisterJobEntryCommandValidator/Validate.cs
@@ -16,7 +16,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Command is required";
+        const string expectedValidationMessage = "Command is required.";
         string error = validationResult[key: "Command"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -33,7 +33,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Register job entry request is required";
+        const string expectedValidationMessage = "Register job entry request is required.";
         string error = validationResult[key: nameof(RegisterJobEntryRequest)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -64,7 +64,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "MaxRetries must be a positive value";
+        const string expectedValidationMessage = "MaxRetries must be a positive value.";
         string error = validationResult[key: nameof(_registerJobEntryCommand.RegisterJobEntryRequest.MaxRetries)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -141,7 +141,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         const string expectedValidationMessage =
-            "At least one value must be provided: Interval for periodic jobs or RunAt for single run jobs";
+            "At least one value must be provided: Interval for periodic jobs or RunAt for single run jobs.";
 
         string error = validationResult[
             key:
@@ -166,7 +166,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "RunAt and Interval cannot be used together";
+        const string expectedValidationMessage = "RunAt and Interval cannot be used together.";
 
         string error = validationResult[
             key:
@@ -195,7 +195,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
         validationResult.Should().NotBeNullOrEmpty();
 
         string expectedValidationMessage =
-            $"RunAt must be greater than current time. Provided: {runAt}. Current: {_clockMock.Object.UtcNow}";
+            $"RunAt must be greater than current time. Provided: {runAt}. Current: {_clockMock.Object.UtcNow}.";
 
         string error = validationResult[key: nameof(_registerJobEntryCommand.RegisterJobEntryRequest.RunAt)];
         error.Should().Be(expected: expectedValidationMessage);
@@ -240,7 +240,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Job entry triggers are required";
+        const string expectedValidationMessage = "Job entry triggers are required.";
         string error = validationResult[key: nameof(_registerJobEntryCommand.RegisterJobEntryRequest.JobEntryTriggers)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -266,7 +266,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Event data is required";
+        const string expectedValidationMessage = "Event data is required.";
         string error = validationResult[key: nameof(JobEntryTrigger.EventData)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -292,7 +292,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Event type is required";
+        const string expectedValidationMessage = "Event type is required.";
         string error = validationResult[key: nameof(JobEntryTrigger.EventType)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -318,7 +318,7 @@ internal sealed class Validate : RegisterJobEntryCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "EventData must be serializable to provided EventType";
+        const string expectedValidationMessage = "EventData must be serializable to provided EventType.";
 
         string error = validationResult[
             key: $"{nameof(JobEntryTrigger.EventType)}|{nameof(JobEntryTrigger.EventData)}"];

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/CreatePreferenceCommandValidator.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/CreatePreferenceCommandValidator.cs
@@ -12,14 +12,14 @@ internal sealed class CreatePreferenceCommandValidator : ICommandValidator<Creat
 
         if (command is null)
         {
-            errors.Add(key: nameof(command).Pascalize(), value: "Command is required");
+            errors.Add(key: nameof(command).Pascalize(), value: "Command is required.");
 
             return errors;
         }
 
         if (command.Preference.UserId == Guid.Empty)
         {
-            errors.Add(key: nameof(command.Preference.UserId), value: "User id cannot be empty");
+            errors.Add(key: nameof(command.Preference.UserId), value: "User id cannot be empty.");
         }
 
         return errors;

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/UpdatePreference/UpdatePreferenceCommandValidator.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/UpdatePreference/UpdatePreferenceCommandValidator.cs
@@ -12,29 +12,29 @@ internal sealed class UpdatePreferenceCommandValidator : ICommandValidator<Updat
 
         if (command is null)
         {
-            errors.Add(key: nameof(command).Pascalize(), value: "Command is required");
+            errors.Add(key: nameof(command).Pascalize(), value: "Command is required.");
         }
 
         if (command?.PreferenceOrUserId == Guid.Empty)
         {
-            errors.Add(key: nameof(command.PreferenceOrUserId), value: "Preferences or user id cannot be empty");
+            errors.Add(key: nameof(command.PreferenceOrUserId), value: "Preferences or user id cannot be empty.");
         }
 
         if (command?.Preference?.FinancePreference is null)
         {
-            errors.Add(key: nameof(command.Preference.FinancePreference), value: "Finance preferences cannot be null");
+            errors.Add(key: nameof(command.Preference.FinancePreference), value: "Finance preferences cannot be null.");
         }
 
         switch (command?.Preference?.FinancePreference?.MaxNumberOfFinancePlanReviewers)
         {
             case < 0:
                 errors.Add(key: nameof(command.Preference.FinancePreference.MaxNumberOfFinancePlanReviewers),
-                    value: "Max number of finance plan reviewers cannot be negative");
+                    value: "Max number of finance plan reviewers cannot be negative.");
 
                 break;
             case > 10:
                 errors.Add(key: nameof(command.Preference.FinancePreference.MaxNumberOfFinancePlanReviewers),
-                    value: "Max number of finance plan reviewers cannot be greater than 10");
+                    value: "Max number of finance plan reviewers cannot be greater than 10.");
 
                 break;
         }
@@ -43,12 +43,12 @@ internal sealed class UpdatePreferenceCommandValidator : ICommandValidator<Updat
         {
             case < 0:
                 errors.Add(key: nameof(command.Preference.FinancePreference.MaxNumberOfSubFinancePlanSubOwners),
-                    value: "Max number of sub finance plan sub owners cannot be negative");
+                    value: "Max number of sub finance plan sub owners cannot be negative.");
 
                 break;
             case > 5:
                 errors.Add(key: nameof(command.Preference.FinancePreference.MaxNumberOfSubFinancePlanSubOwners),
-                    value: "Max number of sub finance plan sub owners cannot be greater than 5");
+                    value: "Max number of sub finance plan sub owners cannot be greater than 5.");
 
                 break;
         }
@@ -56,26 +56,26 @@ internal sealed class UpdatePreferenceCommandValidator : ICommandValidator<Updat
         if (command?.Preference?.NotificationPreference is null)
         {
             errors.Add(key: nameof(command.Preference.NotificationPreference),
-                value: "Notification preferences cannot be null");
+                value: "Notification preferences cannot be null.");
         }
 
         switch (command?.Preference?.NotificationPreference?.SendFinanceReportInterval)
         {
             case < 0:
                 errors.Add(key: nameof(command.Preference.NotificationPreference.SendFinanceReportInterval),
-                    value: "Send finance report interval cannot be negative");
+                    value: "Send finance report interval cannot be negative.");
 
                 break;
             case > 31:
                 errors.Add(key: nameof(command.Preference.NotificationPreference.SendFinanceReportInterval),
-                    value: "Send finance report interval cannot be greater than 31");
+                    value: "Send finance report interval cannot be greater than 31.");
 
                 break;
         }
 
         if (command?.Preference?.GeneralPreference is null)
         {
-            errors.Add(key: nameof(command.Preference.GeneralPreference), value: "General preferences cannot be null");
+            errors.Add(key: nameof(command.Preference.GeneralPreference), value: "General preferences cannot be null.");
         }
 
         return errors;

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/Validate.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/Validate.cs
@@ -15,7 +15,7 @@ internal sealed class Validate : CreatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Command is required";
+        const string expectedValidationMessage = "Command is required.";
         string error = validationResult[key: "Command"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -45,7 +45,7 @@ internal sealed class Validate : CreatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "User id cannot be empty";
+        const string expectedValidationMessage = "User id cannot be empty.";
         string error = validationResult[key: nameof(command.Preference.UserId)];
         error.Should().Be(expected: expectedValidationMessage);
     }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandValidator/Validate.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandValidator/Validate.cs
@@ -14,7 +14,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Command is required";
+        const string expectedValidationMessage = "Command is required.";
         string error = validationResult[key: "Command"];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -44,7 +44,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Preferences or user id cannot be empty";
+        const string expectedValidationMessage = "Preferences or user id cannot be empty.";
         string error = validationResult[key: nameof(_updatePreferenceCommand.PreferenceOrUserId)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -64,7 +64,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Finance preferences cannot be null";
+        const string expectedValidationMessage = "Finance preferences cannot be null.";
         string error = validationResult[key: nameof(_updatePreferenceCommand.Preference.FinancePreference)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -86,7 +86,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Max number of finance plan reviewers cannot be negative";
+        const string expectedValidationMessage = "Max number of finance plan reviewers cannot be negative.";
 
         string error = validationResult[
             key: nameof(_updatePreferenceCommand.Preference.FinancePreference.MaxNumberOfFinancePlanReviewers)];
@@ -111,7 +111,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Max number of finance plan reviewers cannot be greater than 10";
+        const string expectedValidationMessage = "Max number of finance plan reviewers cannot be greater than 10.";
 
         string error = validationResult[
             key: nameof(_updatePreferenceCommand.Preference.FinancePreference.MaxNumberOfFinancePlanReviewers)];
@@ -136,7 +136,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Max number of sub finance plan sub owners cannot be negative";
+        const string expectedValidationMessage = "Max number of sub finance plan sub owners cannot be negative.";
 
         string error = validationResult[
             key: nameof(_updatePreferenceCommand.Preference.FinancePreference.MaxNumberOfSubFinancePlanSubOwners)];
@@ -161,7 +161,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Max number of sub finance plan sub owners cannot be greater than 5";
+        const string expectedValidationMessage = "Max number of sub finance plan sub owners cannot be greater than 5.";
 
         string error = validationResult[
             key: nameof(_updatePreferenceCommand.Preference.FinancePreference.MaxNumberOfSubFinancePlanSubOwners)];
@@ -184,7 +184,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Notification preferences cannot be null";
+        const string expectedValidationMessage = "Notification preferences cannot be null.";
         string error = validationResult[key: nameof(_updatePreferenceCommand.Preference.NotificationPreference)];
         error.Should().Be(expected: expectedValidationMessage);
     }
@@ -206,7 +206,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Send finance report interval cannot be negative";
+        const string expectedValidationMessage = "Send finance report interval cannot be negative.";
 
         string error = validationResult[
             key: nameof(_updatePreferenceCommand.Preference.NotificationPreference.SendFinanceReportInterval)];
@@ -231,7 +231,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "Send finance report interval cannot be greater than 31";
+        const string expectedValidationMessage = "Send finance report interval cannot be greater than 31.";
 
         string error = validationResult[
             key: nameof(_updatePreferenceCommand.Preference.NotificationPreference.SendFinanceReportInterval)];
@@ -254,7 +254,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
 
         // Assert
         validationResult.Should().NotBeNullOrEmpty();
-        const string expectedValidationMessage = "General preferences cannot be null";
+        const string expectedValidationMessage = "General preferences cannot be null.";
         string error = validationResult[key: nameof(_updatePreferenceCommand.Preference.GeneralPreference)];
         error.Should().Be(expected: expectedValidationMessage);
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced consistency of error messages across various validators by adding periods at the end of messages.
	- Updated specific error messages for clarity and uniformity without altering validation logic.
  
- **Tests**
	- Modified expected validation messages in unit tests to reflect the updated error message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->