### PR TITLE
Add command validation assertions

### DIFF
--- a/src/Shared/Tests/Expenso.Shared.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -8,7 +8,7 @@ internal sealed class AccessModifierTests : ArchTestTestBase
     [
         "TestBase",
         "InMemoryFakeLogger",
-        "LoggerAssertions"
+        "Assertions"
     ];
 
     private static readonly string[] NotSealed =

--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/Assertions/CommandValidationAssertions.cs
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/Assertions/CommandValidationAssertions.cs
@@ -1,0 +1,19 @@
+﻿using FluentAssertions;
+
+using FluentValidation.Results;
+
+namespace Expenso.Shared.Tests.Utils.UnitTests.Assertions;
+
+public static class CommandValidationAssertions
+{
+    public static void AssertSingleError(this ValidationResult validationResult, string propertyName,
+        string errorMessage)
+    {
+        validationResult.Should().NotBeNull();
+        validationResult.IsValid.Should().BeFalse();
+        validationResult.Errors.Should().NotBeEmpty();
+        validationResult.Errors.Should().HaveCount(expected: 1);
+        validationResult.Errors[index: 0].PropertyName.Should().Be(expected: propertyName);
+        validationResult.Errors[index: 0].ErrorMessage.Should().Be(expected: errorMessage);
+    }
+}

--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/Expenso.Shared.Tests.Utils.UnitTests.csproj
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/Expenso.Shared.Tests.Utils.UnitTests.csproj
@@ -11,6 +11,7 @@
     <ItemGroup>
         <PackageReference Include="Castle.Core" Version="5.1.1"/>
         <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="FluentValidation" Version="11.10.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
         <PackageReference Include="MockQueryable.EntityFrameworkCore" Version="7.0.2"/>
@@ -34,7 +35,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\Expenso.Shared.System.Logging\Expenso.Shared.System.Logging.csproj"/>
         <ProjectReference Include="..\..\..\Expenso.Shared.System.Types\Expenso.Shared.System.Types.csproj"/>
     </ItemGroup>
 

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/Validate.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/Validate.cs
@@ -1,3 +1,4 @@
+using Expenso.Shared.Tests.Utils.UnitTests.Assertions;
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.CreatePreference;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Request;
 
@@ -33,11 +34,7 @@ internal sealed class Validate : CreatePreferenceCommandValidatorTestBase
         ValidationResult validationResult = TestCandidate.Validate(instance: command);
 
         // Assert
-        validationResult.Should().NotBeNull();
-        validationResult.Errors.Should().NotBeNullOrEmpty();
-        validationResult.Errors.Should().HaveCount(expected: 1);
-        ValidationFailure validationError = validationResult.Errors.First();
-        validationError.PropertyName.Should().Be(expected: "Payload.UserId");
-        validationError.ErrorMessage.Should().Be(expected: "The user ID must not be empty.");
+        validationResult.AssertSingleError(propertyName: "Payload.UserId",
+            errorMessage: "The user ID must not be empty.");
     }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandValidator/UpdatePreferenceCommandValidatorTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandValidator/UpdatePreferenceCommandValidatorTestBase.cs
@@ -34,14 +34,4 @@ internal abstract class UpdatePreferenceCommandValidatorTestBase : TestBase<Test
                 notificationPreferenceValidator: new UpdatePreferenceRequest_NotificationPreferenceValidator(),
                 generalPreferenceValidator: new UpdatePreferenceRequest_GeneralPreferenceValidator()));
     }
-
-    protected static void AssertSingleError(ValidationResult validationResult, string propertyName, string errorMessage)
-    {
-        validationResult.Should().NotBeNull();
-        validationResult.IsValid.Should().BeFalse();
-        validationResult.Errors.Should().NotBeEmpty();
-        validationResult.Errors.Should().HaveCount(expected: 1);
-        validationResult.Errors[index: 0].PropertyName.Should().Be(expected: propertyName);
-        validationResult.Errors[index: 0].ErrorMessage.Should().Be(expected: errorMessage);
-    }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandValidator/Validate.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandValidator/Validate.cs
@@ -1,3 +1,4 @@
+using Expenso.Shared.Tests.Utils.UnitTests.Assertions;
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.UpdatePreference.DTO.Request;
 
 using FluentValidation.Results;
@@ -32,7 +33,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult, propertyName: "PreferenceId",
+        validationResult.AssertSingleError(propertyName: "PreferenceId",
             errorMessage: "The preference ID must not be empty.");
     }
 
@@ -50,7 +51,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult, propertyName: "Payload.FinancePreference",
+        validationResult.AssertSingleError(propertyName: "Payload.FinancePreference",
             errorMessage: "The finance preference must not be empty.");
     }
 
@@ -70,8 +71,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult,
-            propertyName: "Payload.FinancePreference.MaxNumberOfFinancePlanReviewers",
+        validationResult.AssertSingleError(propertyName: "Payload.FinancePreference.MaxNumberOfFinancePlanReviewers",
             errorMessage: "The number of finance plan reviewers must be between 0 and 10.");
     }
 
@@ -91,8 +91,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult,
-            propertyName: "Payload.FinancePreference.MaxNumberOfFinancePlanReviewers",
+        validationResult.AssertSingleError(propertyName: "Payload.FinancePreference.MaxNumberOfFinancePlanReviewers",
             errorMessage: "The number of finance plan reviewers must be between 0 and 10.");
     }
 
@@ -112,8 +111,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult,
-            propertyName: "Payload.FinancePreference.MaxNumberOfSubFinancePlanSubOwners",
+        validationResult.AssertSingleError(propertyName: "Payload.FinancePreference.MaxNumberOfSubFinancePlanSubOwners",
             errorMessage: "The number of finance plan sub-owners must be between 0 and 5.");
     }
 
@@ -133,8 +131,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult,
-            propertyName: "Payload.FinancePreference.MaxNumberOfSubFinancePlanSubOwners",
+        validationResult.AssertSingleError(propertyName: "Payload.FinancePreference.MaxNumberOfSubFinancePlanSubOwners",
             errorMessage: "The number of finance plan sub-owners must be between 0 and 5.");
     }
 
@@ -152,7 +149,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult, propertyName: "Payload.NotificationPreference",
+        validationResult.AssertSingleError(propertyName: "Payload.NotificationPreference",
             errorMessage: "The notification preference must not be empty.");
     }
 
@@ -172,8 +169,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult,
-            propertyName: "Payload.NotificationPreference.SendFinanceReportInterval",
+        validationResult.AssertSingleError(propertyName: "Payload.NotificationPreference.SendFinanceReportInterval",
             errorMessage: "The interval for sending the finance report must be between 0 and 31 days.");
     }
 
@@ -193,8 +189,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult,
-            propertyName: "Payload.NotificationPreference.SendFinanceReportInterval",
+        validationResult.AssertSingleError(propertyName: "Payload.NotificationPreference.SendFinanceReportInterval",
             errorMessage: "The interval for sending the finance report must be between 0 and 31 days.");
     }
 
@@ -212,7 +207,7 @@ internal sealed class Validate : UpdatePreferenceCommandValidatorTestBase
         });
 
         // Assert
-        AssertSingleError(validationResult: validationResult, propertyName: "Payload.GeneralPreference",
+        validationResult.AssertSingleError(propertyName: "Payload.GeneralPreference",
             errorMessage: "The general preference must not be empty.");
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new static class `CommandValidationAssertions` with an extension method `AssertSingleError` for enhanced validation result checks.
  
- **Bug Fixes**
	- Refactored validation assertions in the `CreatePreferenceCommandValidator` and `UpdatePreferenceCommandValidator` test suites for improved accuracy and readability.

- **Chores**
	- Updated project dependencies by adding `FluentValidation` and removing an unnecessary project reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->