### PR TITLE
Use flag enums for permissions and statuses

### DIFF
--- a/src/Api/Expenso.Api/REST/Apis/BudgetSharing/BudgetSharing.BudgetPermissionRequests.Api.http
+++ b/src/Api/Expenso.Api/REST/Apis/BudgetSharing/BudgetSharing.BudgetPermissionRequests.Api.http
@@ -4,8 +4,8 @@ Content-Type: application/json
 Authorization: Bearer {{apiAccessToken}}
 
 ### GetBudgetPermissionRequests
-GET {{apiHostAddress}}/{{budgetSharingRoute}}/budget-permission-requests?status=1&
-    budgetId=fab3cf10-e0da-4bcb-b41c-dfbba1382215
+GET {{apiHostAddress}}/{{budgetSharingRoute}}/budget-permission-requests?permissionType=2&
+    budgetId=fab3cf10-e0da-4bcb-b41c-dfbba1382215&status=1
 Content-Type: application/json
 Authorization: Bearer {{apiAccessToken}}
 

--- a/src/BudgetSharing/Expenso.BudgetSharing.Api/BudgetSharingModule.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Api/BudgetSharingModule.cs
@@ -109,8 +109,10 @@ public sealed class BudgetSharingModule : IModuleDefinition
                 [FromServices] IMessageContextFactory messageContextFactory, [FromQuery] Guid? budgetId = null,
                 [FromQuery] Guid? participantId = null, [FromQuery] Guid? ownerId = null,
                 [FromQuery] bool? forCurrentUser = null,
-                [FromQuery] GetBudgetPermissionRequestsRequest_Status? status = null,
-                [FromQuery] GetBudgetPermissionRequestsRequest_PermissionType? permissionType = null,
+                [FromQuery] GetBudgetPermissionRequestsRequest_Status status =
+                    GetBudgetPermissionRequestsRequest_Status.All,
+                [FromQuery] GetBudgetPermissionRequestsRequest_PermissionType permissionType =
+                    GetBudgetPermissionRequestsRequest_PermissionType.All,
                 CancellationToken cancellationToken = default) =>
             {
                 IReadOnlyCollection<GetBudgetPermissionRequestsResponse>? getPreferences = await handler.HandleAsync(
@@ -216,8 +218,8 @@ public sealed class BudgetSharingModule : IModuleDefinition
                 [FromServices] IMessageContextFactory messageContextFactory, [FromQuery] Guid? budgetId = null,
                 [FromQuery] Guid? ownerId = null, [FromQuery] Guid? participantId = null,
                 [FromQuery] bool? forCurrentUser = null,
-                [FromQuery] GetBudgetPermissionsRequest_PermissionType? permissionType = null,
-                CancellationToken cancellationToken = default) =>
+                [FromQuery] GetBudgetPermissionsRequest_PermissionType permissionType =
+                    GetBudgetPermissionsRequest_PermissionType.All, CancellationToken cancellationToken = default) =>
             {
                 IReadOnlyCollection<GetBudgetPermissionsResponse>? getPreferences = await handler.HandleAsync(
                     query: new GetBudgetPermissionsQuery(MessageContext: messageContextFactory.Current(),

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_PermissionType.cs
@@ -1,9 +1,10 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequest.DTO.Response;
 
+[Flags]
 public enum GetBudgetPermissionRequestResponse_PermissionType
 {
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 3
+    Reviewer = 4
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_PermissionType.cs
@@ -6,5 +6,6 @@ public enum GetBudgetPermissionRequestResponse_PermissionType
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 4
+    Reviewer = 4,
+    All = Owner | SubOwner | Reviewer
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_Status.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_Status.cs
@@ -1,10 +1,11 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequest.DTO.Response;
 
+[Flags]
 public enum GetBudgetPermissionRequestResponse_Status
 {
     None = 0,
     Pending = 1,
     Confirmed = 2,
-    Cancelled = 3,
-    Expired = 4
+    Cancelled = 4,
+    Expired = 8
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_Status.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse_Status.cs
@@ -7,5 +7,6 @@ public enum GetBudgetPermissionRequestResponse_Status
     Pending = 1,
     Confirmed = 2,
     Cancelled = 4,
-    Expired = 8
+    Expired = 8,
+    All = Pending | Confirmed | Cancelled | Expired
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Maps/GetBudgetPermissionRequestsRequestMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Maps/GetBudgetPermissionRequestsRequestMap.cs
@@ -6,62 +6,40 @@ namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBud
 
 public static class GetBudgetPermissionRequestsRequestMap
 {
+    private static readonly Dictionary<GetBudgetPermissionRequestsRequest_PermissionType, PermissionType>
+        PermissionTypeMap = new()
+        {
+            { GetBudgetPermissionRequestsRequest_PermissionType.Owner, PermissionType.Owner },
+            { GetBudgetPermissionRequestsRequest_PermissionType.SubOwner, PermissionType.SubOwner },
+            { GetBudgetPermissionRequestsRequest_PermissionType.Reviewer, PermissionType.Reviewer }
+        };
+
+    private static readonly Dictionary<GetBudgetPermissionRequestsRequest_Status, BudgetPermissionRequestStatus>
+        StatusMap = new()
+        {
+            { GetBudgetPermissionRequestsRequest_Status.Pending, BudgetPermissionRequestStatus.Pending },
+            { GetBudgetPermissionRequestsRequest_Status.Confirmed, BudgetPermissionRequestStatus.Confirmed },
+            { GetBudgetPermissionRequestsRequest_Status.Cancelled, BudgetPermissionRequestStatus.Cancelled },
+            { GetBudgetPermissionRequestsRequest_Status.Expired, BudgetPermissionRequestStatus.Expired }
+        };
+
     public static PermissionType[] MapTo(GetBudgetPermissionRequestsRequest_PermissionType? permissionType)
     {
-        if (permissionType is null or GetBudgetPermissionRequestsRequest_PermissionType.None)
-        {
-            return [PermissionType.None];
-        }
-
-        ICollection<PermissionType> permissionTypes = [];
-
-        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_PermissionType.Owner))
-        {
-            permissionTypes.Add(item: PermissionType.Owner);
-        }
-
-        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_PermissionType.SubOwner))
-        {
-            permissionTypes.Add(item: PermissionType.SubOwner);
-        }
-
-        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_PermissionType.Reviewer))
-        {
-            permissionTypes.Add(item: PermissionType.Reviewer);
-        }
-
-        return permissionTypes.ToArray();
+        return permissionType is null or GetBudgetPermissionRequestsRequest_PermissionType.None
+            ? ( [PermissionType.None])
+            : PermissionTypeMap
+                .Where(predicate: kv => permissionType.Value.HasFlag(flag: kv.Key))
+                .Select(selector: kv => kv.Value)
+                .ToArray();
     }
 
     public static BudgetPermissionRequestStatus[] MapTo(GetBudgetPermissionRequestsRequest_Status? status)
     {
-        if (status is null or GetBudgetPermissionRequestsRequest_Status.None)
-        {
-            return [BudgetPermissionRequestStatus.None];
-        }
-
-        ICollection<BudgetPermissionRequestStatus> budgetPermissionRequestStatus = [];
-
-        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Pending))
-        {
-            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Pending);
-        }
-
-        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Confirmed))
-        {
-            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Confirmed);
-        }
-
-        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Cancelled))
-        {
-            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Cancelled);
-        }
-
-        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Expired))
-        {
-            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Expired);
-        }
-
-        return budgetPermissionRequestStatus.ToArray();
+        return status is null or GetBudgetPermissionRequestsRequest_Status.None
+            ? ( [BudgetPermissionRequestStatus.None])
+            : StatusMap
+                .Where(predicate: kv => status.Value.HasFlag(flag: kv.Key))
+                .Select(selector: kv => kv.Value)
+                .ToArray();
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Maps/GetBudgetPermissionRequestsRequestMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Maps/GetBudgetPermissionRequestsRequestMap.cs
@@ -4,30 +4,64 @@ using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequests.DTO.Maps;
 
-public sealed class GetBudgetPermissionRequestsRequestMap
+public static class GetBudgetPermissionRequestsRequestMap
 {
-    public static PermissionType? MapTo(GetBudgetPermissionRequestsRequest_PermissionType? permissionType)
+    public static PermissionType[] MapTo(GetBudgetPermissionRequestsRequest_PermissionType? permissionType)
     {
-        return permissionType switch
+        if (permissionType is null or GetBudgetPermissionRequestsRequest_PermissionType.None)
         {
-            GetBudgetPermissionRequestsRequest_PermissionType.None => PermissionType.None,
-            GetBudgetPermissionRequestsRequest_PermissionType.Owner => PermissionType.Owner,
-            GetBudgetPermissionRequestsRequest_PermissionType.SubOwner => PermissionType.SubOwner,
-            GetBudgetPermissionRequestsRequest_PermissionType.Reviewer => PermissionType.Reviewer,
-            _ => null
-        };
+            return [PermissionType.None];
+        }
+
+        ICollection<PermissionType> permissionTypes = [];
+
+        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_PermissionType.Owner))
+        {
+            permissionTypes.Add(item: PermissionType.Owner);
+        }
+
+        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_PermissionType.SubOwner))
+        {
+            permissionTypes.Add(item: PermissionType.SubOwner);
+        }
+
+        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_PermissionType.Reviewer))
+        {
+            permissionTypes.Add(item: PermissionType.Reviewer);
+        }
+
+        return permissionTypes.ToArray();
     }
 
-    public static BudgetPermissionRequestStatus? MapTo(GetBudgetPermissionRequestsRequest_Status? status)
+    public static BudgetPermissionRequestStatus[] MapTo(GetBudgetPermissionRequestsRequest_Status? status)
     {
-        return status switch
+        if (status is null or GetBudgetPermissionRequestsRequest_Status.None)
         {
-            GetBudgetPermissionRequestsRequest_Status.None => BudgetPermissionRequestStatus.None,
-            GetBudgetPermissionRequestsRequest_Status.Pending => BudgetPermissionRequestStatus.Pending,
-            GetBudgetPermissionRequestsRequest_Status.Cancelled => BudgetPermissionRequestStatus.Cancelled,
-            GetBudgetPermissionRequestsRequest_Status.Confirmed => BudgetPermissionRequestStatus.Confirmed,
-            GetBudgetPermissionRequestsRequest_Status.Expired => BudgetPermissionRequestStatus.Expired,
-            _ => null
-        };
+            return [BudgetPermissionRequestStatus.None];
+        }
+
+        ICollection<BudgetPermissionRequestStatus> budgetPermissionRequestStatus = [];
+
+        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Pending))
+        {
+            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Pending);
+        }
+
+        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Confirmed))
+        {
+            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Confirmed);
+        }
+
+        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Cancelled))
+        {
+            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Cancelled);
+        }
+
+        if (status.Value.HasFlag(flag: GetBudgetPermissionRequestsRequest_Status.Expired))
+        {
+            budgetPermissionRequestStatus.Add(item: BudgetPermissionRequestStatus.Expired);
+        }
+
+        return budgetPermissionRequestStatus.ToArray();
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Request/GetBudgetPermissionRequestsRequest.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Request/GetBudgetPermissionRequestsRequest.cs
@@ -5,5 +5,6 @@ public sealed record GetBudgetPermissionRequestsRequest(
     Guid? ParticipantId = null,
     Guid? OwnerId = null,
     bool? ForCurrentUser = null,
-    GetBudgetPermissionRequestsRequest_Status? Status = null,
-    GetBudgetPermissionRequestsRequest_PermissionType? PermissionType = null);
+    GetBudgetPermissionRequestsRequest_Status Status = GetBudgetPermissionRequestsRequest_Status.All,
+    GetBudgetPermissionRequestsRequest_PermissionType PermissionType =
+        GetBudgetPermissionRequestsRequest_PermissionType.All);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Request/GetBudgetPermissionRequestsRequest_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Request/GetBudgetPermissionRequestsRequest_PermissionType.cs
@@ -1,9 +1,11 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequests.DTO.Request;
 
+[Flags]
 public enum GetBudgetPermissionRequestsRequest_PermissionType
 {
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 3
+    Reviewer = 4,
+    All = Owner | SubOwner | Reviewer
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Request/GetBudgetPermissionRequestsRequest_Status.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Request/GetBudgetPermissionRequestsRequest_Status.cs
@@ -1,10 +1,12 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequests.DTO.Request;
 
+[Flags]
 public enum GetBudgetPermissionRequestsRequest_Status
 {
     None = 0,
     Pending = 1,
     Confirmed = 2,
-    Cancelled = 3,
-    Expired = 4
+    Cancelled = 4,
+    Expired = 8,
+    All = Pending | Confirmed | Cancelled | Expired
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_PermissionType.cs
@@ -1,9 +1,10 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequests.DTO.Response;
 
+[Flags]
 public enum GetBudgetPermissionRequestsResponse_PermissionType
 {
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 3
+    Reviewer = 4
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_PermissionType.cs
@@ -6,5 +6,6 @@ public enum GetBudgetPermissionRequestsResponse_PermissionType
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 4
+    Reviewer = 4,
+    All = Owner | SubOwner | Reviewer
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_Status.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_Status.cs
@@ -1,10 +1,11 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Read.GetBudgetPermissionRequests.DTO.Response;
 
+[Flags]
 public enum GetBudgetPermissionRequestsResponse_Status
 {
     None = 0,
     Pending = 1,
     Confirmed = 2,
-    Cancelled = 3,
-    Expired = 4
+    Cancelled = 4,
+    Expired = 8
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_Status.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse_Status.cs
@@ -7,5 +7,6 @@ public enum GetBudgetPermissionRequestsResponse_Status
     Pending = 1,
     Confirmed = 2,
     Cancelled = 4,
-    Expired = 8
+    Expired = 8,
+    All = Pending | Confirmed | Cancelled | Expired
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/GetBudgetPermissionRequestsQueryHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/GetBudgetPermissionRequestsQueryHandler.cs
@@ -44,8 +44,8 @@ internal sealed class GetBudgetPermissionRequestsQueryHandler : IQueryHandler<Ge
             BudgetId = BudgetId.Nullable(value: query.Payload?.BudgetId),
             ParticipantId = PersonId.Nullable(value: participantId),
             OwnerId = PersonId.Nullable(value: query.Payload?.OwnerId),
-            Status = GetBudgetPermissionRequestsRequestMap.MapTo(status: query.Payload?.Status),
-            PermissionType = GetBudgetPermissionRequestsRequestMap.MapTo(permissionType: query.Payload?.PermissionType)
+            Statuses = GetBudgetPermissionRequestsRequestMap.MapTo(status: query.Payload?.Status),
+            PermissionTypes = GetBudgetPermissionRequestsRequestMap.MapTo(permissionType: query.Payload?.PermissionType)
         };
 
         IReadOnlyCollection<BudgetPermissionRequest> budgetPermissionRequests =

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Response/GetBudgetPermissionResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Response/GetBudgetPermissionResponse_PermissionType.cs
@@ -1,9 +1,10 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissions.Read.GetBudgetPermission.DTO.Response;
 
+[Flags]
 public enum GetBudgetPermissionResponse_PermissionType
 {
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 3
+    Reviewer = 4
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Response/GetBudgetPermissionResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Response/GetBudgetPermissionResponse_PermissionType.cs
@@ -6,5 +6,6 @@ public enum GetBudgetPermissionResponse_PermissionType
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 4
+    Reviewer = 4,
+    All = Owner | SubOwner | Reviewer
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/DTO/Maps/GetBudgetPermissionsRequestMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/DTO/Maps/GetBudgetPermissionsRequestMap.cs
@@ -5,30 +5,21 @@ namespace Expenso.BudgetSharing.Application.BudgetPermissions.Read.GetBudgetPerm
 
 public static class GetBudgetPermissionsRequestMap
 {
+    private static readonly Dictionary<GetBudgetPermissionsRequest_PermissionType, PermissionType> PermissionTypeMap =
+        new()
+        {
+            { GetBudgetPermissionsRequest_PermissionType.Owner, PermissionType.Owner },
+            { GetBudgetPermissionsRequest_PermissionType.SubOwner, PermissionType.SubOwner },
+            { GetBudgetPermissionsRequest_PermissionType.Reviewer, PermissionType.Reviewer }
+        };
+
     public static PermissionType[] MapTo(GetBudgetPermissionsRequest_PermissionType? permissionType)
     {
-        if (permissionType is null or GetBudgetPermissionsRequest_PermissionType.None)
-        {
-            return [PermissionType.None];
-        }
-
-        ICollection<PermissionType> permissionTypes = [];
-
-        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionsRequest_PermissionType.Owner))
-        {
-            permissionTypes.Add(item: PermissionType.Owner);
-        }
-
-        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionsRequest_PermissionType.SubOwner))
-        {
-            permissionTypes.Add(item: PermissionType.SubOwner);
-        }
-
-        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionsRequest_PermissionType.Reviewer))
-        {
-            permissionTypes.Add(item: PermissionType.Reviewer);
-        }
-
-        return permissionTypes.ToArray();
+        return permissionType is null or GetBudgetPermissionsRequest_PermissionType.None
+            ? ( [PermissionType.None])
+            : PermissionTypeMap
+                .Where(predicate: kv => permissionType.Value.HasFlag(flag: kv.Key))
+                .Select(selector: kv => kv.Value)
+                .ToArray();
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/DTO/Maps/GetBudgetPermissionsRequestMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/DTO/Maps/GetBudgetPermissionsRequestMap.cs
@@ -3,17 +3,32 @@ using Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermission
 
 namespace Expenso.BudgetSharing.Application.BudgetPermissions.Read.GetBudgetPermissions.DTO.Maps;
 
-public sealed class GetBudgetPermissionsRequestMap
+public static class GetBudgetPermissionsRequestMap
 {
-    public static PermissionType? MapTo(GetBudgetPermissionsRequest_PermissionType? permissionType)
+    public static PermissionType[] MapTo(GetBudgetPermissionsRequest_PermissionType? permissionType)
     {
-        return permissionType switch
+        if (permissionType is null or GetBudgetPermissionsRequest_PermissionType.None)
         {
-            GetBudgetPermissionsRequest_PermissionType.None => PermissionType.None,
-            GetBudgetPermissionsRequest_PermissionType.Owner => PermissionType.Owner,
-            GetBudgetPermissionsRequest_PermissionType.SubOwner => PermissionType.SubOwner,
-            GetBudgetPermissionsRequest_PermissionType.Reviewer => PermissionType.Reviewer,
-            _ => null
-        };
+            return [PermissionType.None];
+        }
+
+        ICollection<PermissionType> permissionTypes = [];
+
+        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionsRequest_PermissionType.Owner))
+        {
+            permissionTypes.Add(item: PermissionType.Owner);
+        }
+
+        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionsRequest_PermissionType.SubOwner))
+        {
+            permissionTypes.Add(item: PermissionType.SubOwner);
+        }
+
+        if (permissionType.Value.HasFlag(flag: GetBudgetPermissionsRequest_PermissionType.Reviewer))
+        {
+            permissionTypes.Add(item: PermissionType.Reviewer);
+        }
+
+        return permissionTypes.ToArray();
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/GetBudgetPermissionsQueryHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/GetBudgetPermissionsQueryHandler.cs
@@ -44,7 +44,7 @@ internal sealed class
             BudgetId = BudgetId.Nullable(value: query.Payload?.BudgetId),
             OwnerId = PersonId.Nullable(value: query.Payload?.OwnerId),
             ParticipantId = PersonId.Nullable(value: participantId),
-            PermissionType = GetBudgetPermissionsRequestMap.MapTo(permissionType: query.Payload?.PermissionType)
+            PermissionTypes = GetBudgetPermissionsRequestMap.MapTo(permissionType: query.Payload?.PermissionType)
         };
 
         IReadOnlyList<BudgetPermission> budgetPermissions =

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/Shared/QueryStore/Filters/BudgetPermissionFilter.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/Shared/QueryStore/Filters/BudgetPermissionFilter.cs
@@ -8,4 +8,4 @@ public sealed record BudgetPermissionFilter(
     BudgetId? BudgetId = null,
     PersonId? OwnerId = null,
     PersonId? ParticipantId = null,
-    PermissionType? PermissionType = null);
+    PermissionType[]? PermissionTypes = null);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/Shared/QueryStore/Filters/BudgetPermissionRequestFilter.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/Shared/QueryStore/Filters/BudgetPermissionRequestFilter.cs
@@ -8,5 +8,5 @@ public sealed record BudgetPermissionRequestFilter(
     BudgetId? BudgetId = null,
     PersonId? ParticipantId = null,
     PersonId? OwnerId = null,
-    BudgetPermissionRequestStatus? Status = null,
-    PermissionType? PermissionType = null);
+    BudgetPermissionRequestStatus[]? Statuses = null,
+    PermissionType[]? PermissionTypes = null);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Extensions/BudgetPermissionFilterExtensions.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Extensions/BudgetPermissionFilterExtensions.cs
@@ -39,10 +39,11 @@ public static class BudgetPermissionFilterExtensions
                     x.Permissions.Select(y => y.ParticipantId).Contains(PersonId.New(filter.ParticipantId.Value)));
         }
 
-        if (filter.PermissionType is not null)
+        if (filter.PermissionTypes is not null)
         {
             predicate = AndExpression<BudgetPermission>.And(leftExpression: predicate,
-                rightExpression: x => x.Permissions.Select(y => y.PermissionType).Contains(filter.PermissionType));
+                rightExpression: x =>
+                    x.Permissions.Select(y => y.PermissionType).Any(y => filter.PermissionTypes.Contains(y)));
         }
 
         return predicate;

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Extensions/BudgetPermissionRequestFilterExtensions.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Extensions/BudgetPermissionRequestFilterExtensions.cs
@@ -37,16 +37,16 @@ public static class BudgetPermissionRequestFilterExtensions
                 rightExpression: x => x.OwnerId == filter.OwnerId);
         }
 
-        if (filter.Status is not null)
+        if (filter.Statuses is not null)
         {
             predicate = AndExpression<BudgetPermissionRequest>.And(leftExpression: predicate,
-                rightExpression: x => x.StatusTracker.Status == filter.Status);
+                rightExpression: x => filter.Statuses.Contains(x.StatusTracker.Status));
         }
 
-        if (filter.PermissionType is not null)
+        if (filter.PermissionTypes is not null)
         {
             predicate = AndExpression<BudgetPermissionRequest>.And(leftExpression: predicate,
-                rightExpression: x => x.PermissionType == filter.PermissionType);
+                rightExpression: x => filter.PermissionTypes.Contains(x.PermissionType));
         }
 
         return predicate;

--- a/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Request/GetBudgetPermissionsRequest.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Request/GetBudgetPermissionsRequest.cs
@@ -5,4 +5,4 @@ public sealed record GetBudgetPermissionsRequest(
     Guid? OwnerId = null,
     Guid? ParticipantId = null,
     bool? ForCurrentUser = null,
-    GetBudgetPermissionsRequest_PermissionType? PermissionType = null);
+    GetBudgetPermissionsRequest_PermissionType PermissionType = GetBudgetPermissionsRequest_PermissionType.All);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Request/GetBudgetPermissionsRequest_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Request/GetBudgetPermissionsRequest_PermissionType.cs
@@ -1,9 +1,11 @@
 namespace Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermissions.Request;
 
+[Flags]
 public enum GetBudgetPermissionsRequest_PermissionType
 {
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 3
+    Reviewer = 4,
+    All = Owner | SubOwner | Reviewer
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Response/GetBudgetPermissionsResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Response/GetBudgetPermissionsResponse_PermissionType.cs
@@ -6,5 +6,6 @@ public enum GetBudgetPermissionsResponse_PermissionType
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 4
+    Reviewer = 4,
+    All = Owner | SubOwner | Reviewer
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Response/GetBudgetPermissionsResponse_PermissionType.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Response/GetBudgetPermissionsResponse_PermissionType.cs
@@ -1,9 +1,10 @@
 namespace Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermissions.Response;
 
+[Flags]
 public enum GetBudgetPermissionsResponse_PermissionType
 {
     None = 0,
     Owner = 1,
     SubOwner = 2,
-    Reviewer = 3
+    Reviewer = 4
 }

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Infrastructure/Persistence/Extensions/BudgetPermissionFilterExtensions/ToFilterExpression.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Infrastructure/Persistence/Extensions/BudgetPermissionFilterExtensions/ToFilterExpression.cs
@@ -25,9 +25,9 @@ internal sealed class ToFilterExpression : BudgetPermissionFilterExtensionsTestB
      TestCase(arg1: nameof(BudgetPermissionFilter.ParticipantId), arg2: false, arg3: true),
      TestCase(arg1: nameof(BudgetPermissionFilter.ParticipantId), arg2: false, arg3: false),
      TestCase(arg1: nameof(BudgetPermissionFilter.ParticipantId), arg2: true, arg3: false),
-     TestCase(arg1: nameof(BudgetPermissionFilter.PermissionType), arg2: false, arg3: true),
-     TestCase(arg1: nameof(BudgetPermissionFilter.PermissionType), arg2: false, arg3: false),
-     TestCase(arg1: nameof(BudgetPermissionFilter.PermissionType), arg2: true, arg3: false)]
+     TestCase(arg1: nameof(BudgetPermissionFilter.PermissionTypes), arg2: false, arg3: true),
+     TestCase(arg1: nameof(BudgetPermissionFilter.PermissionTypes), arg2: false, arg3: false),
+     TestCase(arg1: nameof(BudgetPermissionFilter.PermissionTypes), arg2: true, arg3: false)]
     public void Should_ReturnExpectedResult_When_FilterPropertyMatches(string propertyName, bool expectedResult,
         bool blocked)
     {
@@ -79,13 +79,13 @@ internal sealed class ToFilterExpression : BudgetPermissionFilterExtensionsTestB
             {
                 ParticipantId = PersonId.New(value: Guid.NewGuid())
             },
-            nameof(BudgetPermissionFilter.PermissionType) when expectedResult => new BudgetPermissionFilter
+            nameof(BudgetPermissionFilter.PermissionTypes) when expectedResult => new BudgetPermissionFilter
             {
-                PermissionType = _permissionType
+                PermissionTypes = [_permissionType]
             },
-            nameof(BudgetPermissionFilter.PermissionType)when expectedResult is false => new BudgetPermissionFilter
+            nameof(BudgetPermissionFilter.PermissionTypes)when expectedResult is false => new BudgetPermissionFilter
             {
-                PermissionType = PermissionType.Owner
+                PermissionTypes = [PermissionType.Owner]
             },
             _ => throw new ArgumentOutOfRangeException(paramName: nameof(propertyName), actualValue: propertyName,
                 message: "Unsupported property.")

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Infrastructure/Persistence/Extensions/BudgetPermissionRequestFilterExtensions/ToFilterExpression.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Infrastructure/Persistence/Extensions/BudgetPermissionRequestFilterExtensions/ToFilterExpression.cs
@@ -18,14 +18,14 @@ internal sealed class ToFilterExpression : BudgetPermissionRequestFilterExtensio
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.BudgetId), arg2: true),
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.OwnerId), arg2: true),
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.ParticipantId), arg2: true),
-     TestCase(arg1: nameof(BudgetPermissionRequestFilter.PermissionType), arg2: true),
-     TestCase(arg1: nameof(BudgetPermissionRequestFilter.Status), arg2: true),
+     TestCase(arg1: nameof(BudgetPermissionRequestFilter.PermissionTypes), arg2: true),
+     TestCase(arg1: nameof(BudgetPermissionRequestFilter.Statuses), arg2: true),
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.Id), arg2: false),
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.BudgetId), arg2: false),
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.OwnerId), arg2: false),
      TestCase(arg1: nameof(BudgetPermissionRequestFilter.ParticipantId), arg2: false),
-     TestCase(arg1: nameof(BudgetPermissionRequestFilter.PermissionType), arg2: false),
-     TestCase(arg1: nameof(BudgetPermissionRequestFilter.Status), arg2: false)]
+     TestCase(arg1: nameof(BudgetPermissionRequestFilter.PermissionTypes), arg2: false),
+     TestCase(arg1: nameof(BudgetPermissionRequestFilter.Statuses), arg2: false)]
     public void Should_ReturnExpectedResult_When_FilterPropertyMatches(string propertyName, bool expectedResult)
     {
         // Arrange
@@ -79,24 +79,24 @@ internal sealed class ToFilterExpression : BudgetPermissionRequestFilterExtensio
                 {
                     ParticipantId = PersonId.New(value: Guid.NewGuid())
                 },
-            nameof(BudgetPermissionRequestFilter.PermissionType) when expectedResult => new
+            nameof(BudgetPermissionRequestFilter.PermissionTypes) when expectedResult => new
                 BudgetPermissionRequestFilter
                 {
-                    PermissionType = _permissionType
+                    PermissionTypes = [_permissionType]
                 },
-            nameof(BudgetPermissionRequestFilter.PermissionType)when expectedResult is false => new
+            nameof(BudgetPermissionRequestFilter.PermissionTypes)when expectedResult is false => new
                 BudgetPermissionRequestFilter
                 {
-                    PermissionType = PermissionType.Owner
+                    PermissionTypes = [PermissionType.Owner]
                 },
-            nameof(BudgetPermissionRequestFilter.Status)when expectedResult => new BudgetPermissionRequestFilter
+            nameof(BudgetPermissionRequestFilter.Statuses)when expectedResult => new BudgetPermissionRequestFilter
             {
-                Status = _status
+                Statuses = [_status]
             },
-            nameof(BudgetPermissionRequestFilter.Status)when expectedResult is false => new
+            nameof(BudgetPermissionRequestFilter.Statuses)when expectedResult is false => new
                 BudgetPermissionRequestFilter
                 {
-                    Status = BudgetPermissionRequestStatus.Confirmed
+                    Statuses = [BudgetPermissionRequestStatus.Confirmed]
                 },
             _ => throw new ArgumentOutOfRangeException(paramName: nameof(propertyName), actualValue: propertyName,
                 message: "Unsupported property.")

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequest_PreferenceTypes.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequest_PreferenceTypes.cs
@@ -6,5 +6,6 @@ public enum GetPreferenceRequest_PreferenceTypes
     None = 0,
     Finance = 1,
     Notification = 2,
-    General = 4
+    General = 4,
+    All = Finance | Notification | General
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequest_PreferenceTypes.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequest_PreferenceTypes.cs
@@ -6,6 +6,5 @@ public enum GetPreferenceRequest_PreferenceTypes
     None = 0,
     Finance = 1,
     Notification = 2,
-    General = 4,
-    All = Finance | Notification | General
+    General = 4
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/Filters/PreferenceQuerySpecification.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/Filters/PreferenceQuerySpecification.cs
@@ -11,6 +11,13 @@ internal sealed record PreferenceQuerySpecification(
     bool? UseTracking = null,
     PreferenceTypes? PreferenceType = null)
 {
+    private static readonly Dictionary<PreferenceTypes, Expression<Func<Preference, object>>> PreferenceTypeMap = new()
+    {
+        { PreferenceTypes.Finance, x => x.FinancePreference! },
+        { PreferenceTypes.Notification, x => x.NotificationPreference! },
+        { PreferenceTypes.General, x => x.GeneralPreference! }
+    };
+
     public Expression<Func<Preference, bool>> Filter()
     {
         Expression<Func<Preference, bool>> predicate = p => true;
@@ -32,24 +39,11 @@ internal sealed record PreferenceQuerySpecification(
 
     public IEnumerable<Expression<Func<Preference, object>>> Include()
     {
-        List<Expression<Func<Preference, object>>> includes = [];
         PreferenceTypes preferenceTypes = PreferenceType ?? PreferenceTypes.None;
 
-        if (preferenceTypes.HasFlag(flag: PreferenceTypes.Finance))
-        {
-            includes.Add(item: x => x.FinancePreference!);
-        }
-
-        if (preferenceTypes.HasFlag(flag: PreferenceTypes.Notification))
-        {
-            includes.Add(item: x => x.NotificationPreference!);
-        }
-
-        if (preferenceTypes.HasFlag(flag: PreferenceTypes.General))
-        {
-            includes.Add(item: x => x.GeneralPreference!);
-        }
-
-        return includes.ToArray();
+        return PreferenceTypeMap
+            .Where(predicate: kv => preferenceTypes.HasFlag(flag: kv.Key))
+            .Select(selector: kv => kv.Value)
+            .ToArray();
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced API for budget permission requests with new filtering capabilities, allowing for multiple statuses and permission types.
	- Updated enumerations to support bitwise operations for permissions and statuses.

- **Bug Fixes**
	- Resolved issues related to handling nullable types in budget permission requests, ensuring default values are set.

- **Documentation**
	- Updated comments and documentation to reflect changes in property names and functionality.

- **Tests**
	- Modified test cases to align with new pluralized property names for permissions and statuses in filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->