### PR TITLE
Add possibility to track context in proxies

### DIFF
--- a/docker/sql/init.sql
+++ b/docker/sql/init.sql
@@ -2,27 +2,27 @@ BEGIN;
 
 DO
 $$
-BEGIN
+    BEGIN
         CREATE
-DATABASE keycloak;
+            DATABASE keycloak;
         CREATE
-USER keycloak WITH ENCRYPTED PASSWORD '<your_password>';
+            USER keycloak WITH ENCRYPTED PASSWORD '<your_password>';
         GRANT ALL PRIVILEGES ON DATABASE
-keycloak TO keycloak;
-EXECUTE 'GRANT ALL ON SCHEMA public TO keycloak' USING 'keycloak';
+            keycloak TO keycloak;
+        EXECUTE 'GRANT ALL ON SCHEMA public TO keycloak' USING 'keycloak';
 
-CREATE
-DATABASE expenso;
         CREATE
-USER expenso WITH ENCRYPTED PASSWORD '<your_password>';
+            DATABASE expenso;
+        CREATE
+            USER expenso WITH ENCRYPTED PASSWORD '<your_password>';
         GRANT ALL PRIVILEGES ON DATABASE
-expenso TO expenso;
-EXECUTE 'GRANT ALL ON SCHEMA public TO expenso' USING 'expenso';
+            expenso TO expenso;
+        EXECUTE 'GRANT ALL ON SCHEMA public TO expenso' USING 'expenso';
 
-COMMIT;
-EXCEPTION
+        COMMIT;
+    EXCEPTION
         WHEN OTHERS THEN
             ROLLBACK;
             RAISE;
-END
+    END
 $$;

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/IAM/FakeIamProxy.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/IAM/FakeIamProxy.cs
@@ -10,6 +10,7 @@ using Expenso.IAM.Shared.DTO.GetUserById.Response;
 using Expenso.IAM.Shared.DTO.GetUsers.Request;
 using Expenso.IAM.Shared.DTO.GetUsers.Response;
 using Expenso.Shared.System.Types.Exceptions;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 
 using Keycloak.AuthServices.Sdk.Admin.Models;
 
@@ -48,24 +49,24 @@ internal sealed class FakeIamProxy : IIamProxy
         }
     ];
 
-    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request,
-        CancellationToken cancellationToken)
+    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request,IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default)
     {
         return GetUserByIdResponseMap.MapTo(user: await Task.FromResult(
             result: _users.FirstOrDefault(predicate: x => x.Id == request.UserId) ??
                     throw new NotFoundException(message: $"User with id {request.UserId} not found.")));
     }
 
-    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,
-        CancellationToken cancellationToken)
+    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default)
     {
         return GetUserByEmailResponseMap.MapTo(user: await Task.FromResult(
             result: _users.FirstOrDefault(predicate: x => x.Email == request.Email) ??
                     throw new NotFoundException(message: $"User with email {request.Email} not found.")));
     }
 
-    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,
-        CancellationToken cancellationToken)
+    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default)
     {
         if (request.Limit <= 0)
         {

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/IAM/FakeIamProxy.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/IAM/FakeIamProxy.cs
@@ -23,7 +23,7 @@ internal sealed class FakeIamProxy : IIamProxy
 
     private readonly IReadOnlyCollection<UserRepresentation> _users =
     [
-        new UserRepresentation
+        new()
         {
             Id = UserDataInitializer.UserIds[index: 0].ToString(),
             FirstName = "Sergio",
@@ -31,7 +31,7 @@ internal sealed class FakeIamProxy : IIamProxy
             Username = "SHuang",
             Email = ExistingEmails[0]
         },
-        new UserRepresentation
+        new()
         {
             Id = new Guid(g: "32b61237-4859-4281-8702-6fa3e4c72d67").ToString(),
             FirstName = "Krishna",
@@ -39,7 +39,7 @@ internal sealed class FakeIamProxy : IIamProxy
             Username = "KLeee",
             Email = ExistingEmails[1]
         },
-        new UserRepresentation
+        new()
         {
             Id = new Guid(g: "0d53ecf2-cef4-47ca-974a-3f1b395cd2c4").ToString(),
             FirstName = "Vincent",
@@ -49,24 +49,24 @@ internal sealed class FakeIamProxy : IIamProxy
         }
     ];
 
-    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request,IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return GetUserByIdResponseMap.MapTo(user: await Task.FromResult(
             result: _users.FirstOrDefault(predicate: x => x.Id == request.UserId) ??
                     throw new NotFoundException(message: $"User with id {request.UserId} not found.")));
     }
 
-    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return GetUserByEmailResponseMap.MapTo(user: await Task.FromResult(
             result: _users.FirstOrDefault(predicate: x => x.Email == request.Email) ??
                     throw new NotFoundException(message: $"User with email {request.Email} not found.")));
     }
 
-    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         if (request.Limit <= 0)
         {

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/TestBase.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/TestBase.cs
@@ -14,7 +14,10 @@ internal abstract class TestBase
     public virtual Task SetUpAsync()
     {
         MessageContextFactoryMock = new Mock<IMessageContextFactory>();
-        MessageContextFactoryMock.Setup(expression: x => x.Current(It.IsAny<Guid?>())).Returns(value: _messageContext);
+
+        MessageContextFactoryMock
+            .Setup(expression: x => x.Current(It.IsAny<Guid?>(), It.IsAny<string?>()))
+            .Returns(value: _messageContext);
         _httpClient = WebApp.Instance.GetHttpClient();
 
         return Task.CompletedTask;

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/TestBase.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/TestBase.cs
@@ -17,7 +17,9 @@ internal abstract class TestBase
 
         MessageContextFactoryMock
             .Setup(expression: x => x.Current(It.IsAny<Guid?>(), It.IsAny<string?>()))
-            .Returns(value: _messageContext);
+            .Returns(value: new MessageContext(messageId: Guid.NewGuid(), correlationId: Guid.NewGuid(),
+                requestedBy: Guid.NewGuid(), timestamp: DateTimeOffset.Now, module: "TestModule"));
+
         _httpClient = WebApp.Instance.GetHttpClient();
 
         return Task.CompletedTask;
@@ -31,15 +33,6 @@ internal abstract class TestBase
 
         return Task.CompletedTask;
     }
-
-    private readonly MessageContext _messageContext = new()
-    {
-        MessageId = Guid.NewGuid(),
-        CorrelationId = Guid.NewGuid(),
-        RequestedBy = Guid.NewGuid(),
-        Timestamp = DateTimeOffset.Now,
-        ModuleId = "TestModule"
-    };
 
     protected Mock<IMessageContextFactory> MessageContextFactoryMock { get; set; } = null!;
 

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/TestData/IAM/UserDataInitializer.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/TestData/IAM/UserDataInitializer.cs
@@ -4,10 +4,10 @@ internal static class UserDataInitializer
 {
     public static readonly IList<Guid> UserIds =
     [
-        new Guid(g: "1eee2753-4ebd-40e8-af35-f09bbce44bf9"),
-        new Guid(g: "3318e89e-fe27-453b-b9cb-3edce39ee187"),
-        new Guid(g: "41e0197a-014f-419a-9521-d0946e88818d"),
-        new Guid(g: "a8033772-3f5a-4127-8d23-de01aaf4f5d9"),
-        new Guid(g: "b754111e-39b4-4d54-92ee-128f3b456d0a")
+        new(g: "1eee2753-4ebd-40e8-af35-f09bbce44bf9"),
+        new(g: "3318e89e-fe27-453b-b9cb-3edce39ee187"),
+        new(g: "41e0197a-014f-419a-9521-d0946e88818d"),
+        new(g: "a8033772-3f5a-4127-8d23-de01aaf4f5d9"),
+        new(g: "b754111e-39b4-4d54-92ee-128f3b456d0a")
     ];
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/Expenso.BudgetSharing.Application.csproj
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/Expenso.BudgetSharing.Application.csproj
@@ -10,6 +10,7 @@
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Commands\Expenso.Shared.Commands.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Database\Expenso.Shared.Database.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Queries\Expenso.Shared.Queries.csproj"/>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Modules.Constants\Expenso.Shared.System.Modules.Constants.csproj"/>
         <ProjectReference Include="..\Expenso.BudgetSharing.Domain\Expenso.BudgetSharing.Domain.csproj"/>
         <ProjectReference Include="..\Expenso.BudgetSharing.Shared\Expenso.BudgetSharing.Shared.csproj"/>
     </ItemGroup>

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/Proxy/BudgetSharingProxy.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/Proxy/BudgetSharingProxy.cs
@@ -27,9 +27,7 @@ internal sealed class BudgetSharingProxy : IBudgetSharingProxy
     {
         return await _queryDispatcher.QueryAsync(
             query: new GetBudgetPermissionsQuery(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.BudgetSharingModule)
-                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.BudgetSharingModule),
-                Payload: request), cancellationToken: cancellationToken);
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.BudgetSharingModule), Payload: request), cancellationToken: cancellationToken);
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/Proxy/BudgetSharingProxy.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/Proxy/BudgetSharingProxy.cs
@@ -2,23 +2,19 @@ using Expenso.BudgetSharing.Application.BudgetPermissions.Read.GetBudgetPermissi
 using Expenso.BudgetSharing.Shared;
 using Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermissions.Request;
 using Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermissions.Response;
-using Expenso.Shared.Commands.Dispatchers;
 using Expenso.Shared.Queries.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.BudgetSharing.Application.Proxy;
 
 internal sealed class BudgetSharingProxy : IBudgetSharingProxy
 {
-    private readonly ICommandDispatcher _commandDispatcher;
     private readonly IMessageContextFactory _messageContextFactory;
     private readonly IQueryDispatcher _queryDispatcher;
 
-    public BudgetSharingProxy(ICommandDispatcher commandDispatcher, IQueryDispatcher queryDispatcher,
-        IMessageContextFactory messageContextFactory)
+    public BudgetSharingProxy(IQueryDispatcher queryDispatcher, IMessageContextFactory messageContextFactory)
     {
-        _commandDispatcher = commandDispatcher ?? throw new ArgumentNullException(paramName: nameof(commandDispatcher));
-
         _messageContextFactory = messageContextFactory ??
                                  throw new ArgumentNullException(paramName: nameof(messageContextFactory));
 
@@ -26,10 +22,14 @@ internal sealed class BudgetSharingProxy : IBudgetSharingProxy
     }
 
     public async Task<IReadOnlyCollection<GetBudgetPermissionsResponse>?> GetBudgetPermissionsAsync(
-        GetBudgetPermissionsRequest request, CancellationToken cancellationToken = default)
+        GetBudgetPermissionsRequest request, IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default)
     {
-        GetBudgetPermissionsQuery query = new(MessageContext: _messageContextFactory.Current(), Payload: request);
-
-        return await _queryDispatcher.QueryAsync(query: query, cancellationToken: cancellationToken);
+        return await _queryDispatcher.QueryAsync(
+            query: new GetBudgetPermissionsQuery(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.BudgetSharingModule)
+                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.BudgetSharingModule),
+                Payload: request), cancellationToken: cancellationToken);
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestCancelledEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestCancelledEventHandler.cs
@@ -89,7 +89,7 @@ internal sealed class
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         if (participant?.CanSendNotifications is true)
@@ -135,7 +135,7 @@ internal sealed class
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestConfirmedEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestConfirmedEventHandler.cs
@@ -83,7 +83,7 @@ internal sealed class
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         if (participant?.CanSendNotifications is true)
@@ -125,7 +125,7 @@ internal sealed class
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestExpiredEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestExpiredEventHandler.cs
@@ -34,12 +34,11 @@ internal sealed class
 
     public async Task HandleAsync(BudgetPermissionRequestExpiredEvent @event, CancellationToken cancellationToken)
     {
-        NotificationRecipients notificationRecipients =
-            await _iamProxyService.GetUserNotificationAvailability(messageContext: @event.MessageContext,
-                ownerId: @event.OwnerId, participantIds:
-                [
-                    @event.ParticipantId
-                ], cancellationToken: cancellationToken);
+        NotificationRecipients notificationRecipients = await _iamProxyService.GetUserNotificationAvailability(
+            messageContext: @event.MessageContext, ownerId: @event.OwnerId, participantIds:
+            [
+                @event.ParticipantId
+            ], cancellationToken: cancellationToken);
 
         NotificationRecipient? participant = notificationRecipients.Participants.FirstOrDefault();
 
@@ -89,7 +88,7 @@ internal sealed class
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         if (participant?.CanSendNotifications is true)
@@ -135,7 +134,7 @@ internal sealed class
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestedEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/EventHandlers/Internal/BudgetPermissionRequestedEventHandler.cs
@@ -33,12 +33,11 @@ internal sealed class BudgetPermissionRequestedEventHandler : IDomainEventHandle
 
     public async Task HandleAsync(BudgetPermissionRequestedEvent @event, CancellationToken cancellationToken)
     {
-        NotificationRecipients notificationRecipients =
-            await _iamProxyService.GetUserNotificationAvailability(messageContext: @event.MessageContext,
-                ownerId: @event.OwnerId, participantIds:
-                [
-                    @event.ParticipantId
-                ], cancellationToken: cancellationToken);
+        NotificationRecipients notificationRecipients = await _iamProxyService.GetUserNotificationAvailability(
+            messageContext: @event.MessageContext, ownerId: @event.OwnerId, participantIds:
+            [
+                @event.ParticipantId
+            ], cancellationToken: cancellationToken);
 
         NotificationRecipient? participant = notificationRecipients.Participants.FirstOrDefault();
 
@@ -88,7 +87,7 @@ internal sealed class BudgetPermissionRequestedEventHandler : IDomainEventHandle
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         if (participant?.CanSendNotifications is true)
@@ -132,7 +131,7 @@ internal sealed class BudgetPermissionRequestedEventHandler : IDomainEventHandle
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionBlockedEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionBlockedEventHandler.cs
@@ -77,7 +77,7 @@ internal sealed class BudgetPermissionBlockedEventHandler : IDomainEventHandler<
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         foreach (NotificationRecipient participant in notificationRecipients.Participants)
@@ -122,7 +122,7 @@ internal sealed class BudgetPermissionBlockedEventHandler : IDomainEventHandler<
                     NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
                 await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                    cancellationToken: cancellationToken);
+                    messageContext: @event.MessageContext, cancellationToken: cancellationToken);
             }
         }
     }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionGrantedEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionGrantedEventHandler.cs
@@ -33,12 +33,11 @@ internal sealed class BudgetPermissionGrantedEventHandler : IDomainEventHandler<
 
     public async Task HandleAsync(BudgetPermissionGrantedEvent @event, CancellationToken cancellationToken)
     {
-        NotificationRecipients notificationRecipients =
-            await _iamProxyService.GetUserNotificationAvailability(messageContext: @event.MessageContext,
-                ownerId: @event.OwnerId, participantIds:
-                [
-                    @event.ParticipantId
-                ], cancellationToken: cancellationToken);
+        NotificationRecipients notificationRecipients = await _iamProxyService.GetUserNotificationAvailability(
+            messageContext: @event.MessageContext, ownerId: @event.OwnerId, participantIds:
+            [
+                @event.ParticipantId
+            ], cancellationToken: cancellationToken);
 
         NotificationRecipient? participant = notificationRecipients.Participants.FirstOrDefault();
 
@@ -81,7 +80,7 @@ internal sealed class BudgetPermissionGrantedEventHandler : IDomainEventHandler<
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         if (participant?.CanSendNotifications is true)
@@ -119,7 +118,7 @@ internal sealed class BudgetPermissionGrantedEventHandler : IDomainEventHandler<
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionUnblockedEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionUnblockedEventHandler.cs
@@ -71,7 +71,7 @@ internal sealed class BudgetPermissionUnblockedEventHandler : IDomainEventHandle
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         foreach (NotificationRecipient participant in notificationRecipients.Participants)
@@ -114,7 +114,7 @@ internal sealed class BudgetPermissionUnblockedEventHandler : IDomainEventHandle
                     NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
                 await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                    cancellationToken: cancellationToken);
+                    messageContext: @event.MessageContext, cancellationToken: cancellationToken);
             }
         }
     }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionWithdrawnEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionWithdrawnEventHandler.cs
@@ -110,7 +110,7 @@ internal sealed class BudgetPermissionWithdrawnEventHandler : IDomainEventHandle
             message.AppendLine(value: "Best regards,");
             message.AppendLine(value: "Expenso Team");
 
-            SendNotificationRequest participantNotification = new(Subject: "Budget Permission Granted",
+            SendNotificationRequest participantNotification = new(Subject: "Budget Permission Withdrawn",
                 Content: message.ToString(),
                 NotificationContext: new SendNotificationRequest_NotificationContext(
                     From: _notificationSettings.Email?.From ??

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionWithdrawnEventHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissions/EventHandlers/Internal/BudgetPermissionWithdrawnEventHandler.cs
@@ -80,7 +80,7 @@ internal sealed class BudgetPermissionWithdrawnEventHandler : IDomainEventHandle
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: ownerNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
 
         if (participant?.CanSendNotifications is true)
@@ -119,7 +119,7 @@ internal sealed class BudgetPermissionWithdrawnEventHandler : IDomainEventHandle
                 NotificationType: _notificationSettings.CreateNotificationTypeBasedOnSettings());
 
             await _communicationProxy.SendNotificationAsync(request: participantNotification,
-                cancellationToken: cancellationToken);
+                messageContext: @event.MessageContext, cancellationToken: cancellationToken);
         }
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Shared/IBudgetSharingProxy.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Shared/IBudgetSharingProxy.cs
@@ -1,10 +1,12 @@
 using Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermissions.Request;
 using Expenso.BudgetSharing.Shared.DTO.API.BudgetPermissions.GetBudgetPermissions.Response;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.BudgetSharing.Shared;
 
 public interface IBudgetSharingProxy
 {
     Task<IReadOnlyCollection<GetBudgetPermissionsResponse>?> GetBudgetPermissionsAsync(
-        GetBudgetPermissionsRequest request, CancellationToken cancellationToken = default);
+        GetBudgetPermissionsRequest request, IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/BudgetSharingProxyTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/BudgetSharingProxyTestBase.cs
@@ -12,8 +12,7 @@ internal abstract class BudgetSharingProxyTestBase : TestBase<BudgetSharing.Appl
     public void SetUp()
     {
         TestCandidate = new BudgetSharing.Application.Proxy.BudgetSharingProxy(
-            queryDispatcher: _queryDispatcherMock.Object,
-            messageContextFactory: MessageContextFactoryMock.Object);
+            queryDispatcher: _queryDispatcherMock.Object, messageContextFactory: MessageContextFactoryMock.Object);
     }
 
     protected readonly Mock<IQueryDispatcher> _queryDispatcherMock = new();

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/BudgetSharingProxyTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/BudgetSharingProxyTestBase.cs
@@ -1,5 +1,4 @@
-﻿using Expenso.Shared.Commands.Dispatchers;
-using Expenso.Shared.Queries.Dispatchers;
+﻿using Expenso.Shared.Queries.Dispatchers;
 using Expenso.Shared.Tests.Utils.UnitTests;
 
 using Moq;
@@ -13,10 +12,9 @@ internal abstract class BudgetSharingProxyTestBase : TestBase<BudgetSharing.Appl
     public void SetUp()
     {
         TestCandidate = new BudgetSharing.Application.Proxy.BudgetSharingProxy(
-            commandDispatcher: _commandDispatcherMock.Object, queryDispatcher: _queryDispatcherMock.Object,
+            queryDispatcher: _queryDispatcherMock.Object,
             messageContextFactory: MessageContextFactoryMock.Object);
     }
 
-    protected readonly Mock<ICommandDispatcher> _commandDispatcherMock = new();
     protected readonly Mock<IQueryDispatcher> _queryDispatcherMock = new();
 }

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/GetBudgetPermissionsAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/GetBudgetPermissionsAsync.cs
@@ -19,7 +19,7 @@ internal sealed class GetBudgetPermissionsAsync : BudgetSharingProxyTestBase
 
         List<GetBudgetPermissionsResponse> response =
         [
-            new GetBudgetPermissionsResponse(Id: Guid.NewGuid(), BudgetId: Guid.NewGuid(), OwnerId: Guid.NewGuid(),
+            new(Id: Guid.NewGuid(), BudgetId: Guid.NewGuid(), OwnerId: Guid.NewGuid(),
                 Permissions: new List<GetBudgetPermissionsResponse_Permission>
                 {
                     new(ParticipantId: Guid.NewGuid(),

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipantAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipantAsync.cs
@@ -4,6 +4,7 @@ using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 using Expenso.IAM.Shared.DTO.GetUserByEmail.Request;
 using Expenso.Shared.Domain.Types.Exceptions;
 using Expenso.Shared.System.Types.Exceptions;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 
 using FluentAssertions;
 
@@ -21,7 +22,7 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
         // Arrange
         _iamProxyMock
             .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
-                It.IsAny<CancellationToken>()))
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getUserByEmailResponse);
 
         _budgetPermissionRepositoryMock
@@ -89,8 +90,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .ReturnsAsync(value: _budgetPermission);
 
         _iamProxyMock
-            .Setup(expression: x =>
-                x.GetUserByEmailAsync(new GetUserByEmailRequest(_email), It.IsAny<CancellationToken>()))
+            .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(exception: new NotFoundException(message: $"User with email {_email} not found"));
 
         // Act
@@ -114,8 +115,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .ReturnsAsync(value: _budgetPermission);
 
         _iamProxyMock
-            .Setup(expression: x =>
-                x.GetUserByEmailAsync(new GetUserByEmailRequest(_email), It.IsAny<CancellationToken>()))
+            .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getUserByEmailResponse with
             {
                 UserId = "db9aUuZIcbRkWg3"
@@ -140,8 +141,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
     {
         // Arrange
         _iamProxyMock
-            .Setup(expression: x =>
-                x.GetUserByEmailAsync(new GetUserByEmailRequest(_email), It.IsAny<CancellationToken>()))
+            .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getUserByEmailResponse);
 
         _budgetPermission.AddPermission(participantId: _participantId, permissionType: _permissionType);
@@ -171,8 +172,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
     {
         // Arrange
         _iamProxyMock
-            .Setup(expression: x =>
-                x.GetUserByEmailAsync(new GetUserByEmailRequest(_email), It.IsAny<CancellationToken>()))
+            .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getUserByEmailResponse);
 
         _budgetPermissionRepositoryMock
@@ -208,8 +209,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
     {
         // Arrange
         _iamProxyMock
-            .Setup(expression: x =>
-                x.GetUserByEmailAsync(new GetUserByEmailRequest(_email), It.IsAny<CancellationToken>()))
+            .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getUserByEmailResponse);
 
         _budgetPermissionRepositoryMock
@@ -245,8 +246,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
     {
         // Arrange
         _iamProxyMock
-            .Setup(expression: x =>
-                x.GetUserByEmailAsync(new GetUserByEmailRequest(_email), It.IsAny<CancellationToken>()))
+            .Setup(expression: x => x.GetUserByEmailAsync(new GetUserByEmailRequest(_email),
+                It.IsAny<IMessageContext>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getUserByEmailResponse);
 
         _budgetPermissionRepositoryMock

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationAsync.cs
@@ -3,6 +3,7 @@ using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.BudgetPermissions.Events;
 using Expenso.Shared.Domain.Types.Exceptions;
 using Expenso.Shared.System.Types.Exceptions;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Request;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Response;
 
@@ -32,7 +33,8 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             .Setup(expression: x =>
                 x.GetPreferences(
                     new GetPreferencesRequest(null, _budgetPermission.OwnerId.Value,
-                        GetPreferencesRequest_PreferenceTypes.Finance), It.IsAny<CancellationToken>()))
+                        GetPreferencesRequest_PreferenceTypes.Finance), It.IsAny<IMessageContext>(),
+                    It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferenceResponse);
 
         // Act
@@ -127,7 +129,8 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             .Setup(expression: x =>
                 x.GetPreferences(
                     new GetPreferencesRequest(null, _budgetPermission.OwnerId.Value,
-                        GetPreferencesRequest_PreferenceTypes.Finance), It.IsAny<CancellationToken>()))
+                        GetPreferencesRequest_PreferenceTypes.Finance), It.IsAny<IMessageContext>(),
+                    It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: null);
 
         // Act
@@ -160,7 +163,8 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             .Setup(expression: x =>
                 x.GetPreferences(
                     new GetPreferencesRequest(null, _budgetPermission.OwnerId.Value,
-                        GetPreferencesRequest_PreferenceTypes.Finance), It.IsAny<CancellationToken>()))
+                        GetPreferencesRequest_PreferenceTypes.Finance), It.IsAny<IMessageContext>(),
+                    It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferenceResponse with
             {
                 FinancePreference = new GetPreferencesResponse_FinancePreference(AllowAddFinancePlanSubOwners: false,

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissions/EventHandlers/BudgetPermissionUnblockedEventHandler/HandleAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissions/EventHandlers/BudgetPermissionUnblockedEventHandler/HandleAsync.cs
@@ -23,7 +23,7 @@ internal sealed class HandleAsync : HandleAsyncBase<
         await Should_Call_GetUserNotificationAvailability_With_MessageContext_Internal(
             notificationCount: Times.AtLeast(callCount: 3));
     }
-    
+
     protected override BudgetPermissionUnblockedEvent CreateEvent()
     {
         return new BudgetPermissionUnblockedEvent(MessageContext: MessageContextFactoryMock.Object.Current(),

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/Shared/Base/DomainEventHandlers/HandleAsyncBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/Shared/Base/DomainEventHandlers/HandleAsyncBase.cs
@@ -17,17 +17,17 @@ internal abstract class HandleAsyncBase<T, TEvent> : EventHandlerTestBase<T, TEv
     public void Should_NotThrow()
     {
         // Arrange
+        TEvent @event = CreateEvent();
+
         _iIamProxyServiceMock
-            .Setup(expression: x => x.GetUserNotificationAvailability(MessageContextFactoryMock.Object.Current(null),
-                _defaultOwnerId, new[]
+            .Setup(expression: x => x.GetUserNotificationAvailability(
+                It.Is<IMessageContext>(mc => mc == @event.MessageContext), _defaultOwnerId, new[]
                     {
                         _defaultParticipantId
                     }
                     .ToList()
                     .AsReadOnly(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _defaultNotificationRecipients);
-
-        TEvent @event = CreateEvent();
 
         // Assert
         Assert.DoesNotThrowAsync(code: () => TestCandidate.HandleAsync(@event: @event, cancellationToken: default));
@@ -43,9 +43,11 @@ internal abstract class HandleAsyncBase<T, TEvent> : EventHandlerTestBase<T, TEv
     public async Task Should_SendNotificationToOwner_When_ParticipantHasNotBeenFound()
     {
         // Arrange
+        TEvent @event = CreateEvent();
+
         _iIamProxyServiceMock
-            .Setup(expression: x => x.GetUserNotificationAvailability(MessageContextFactoryMock.Object.Current(null),
-                _defaultOwnerId, new[]
+            .Setup(expression: x => x.GetUserNotificationAvailability(
+                It.Is<IMessageContext>(mc => mc == @event.MessageContext), _defaultOwnerId, new[]
                     {
                         _defaultParticipantId
                     }
@@ -56,15 +58,13 @@ internal abstract class HandleAsyncBase<T, TEvent> : EventHandlerTestBase<T, TEv
                 Participants = new List<NotificationRecipient>()
             });
 
-        TEvent @event = CreateEvent();
-
         // Act
         await TestCandidate.HandleAsync(@event: @event, cancellationToken: default);
 
         // Assert
         _communicationProxyMock.Verify(
-            expression: x =>
-                x.SendNotificationAsync(It.IsAny<SendNotificationRequest>(), It.IsAny<CancellationToken>()),
+            expression: x => x.SendNotificationAsync(It.IsAny<SendNotificationRequest>(),
+                It.Is<IMessageContext>(mc => mc == @event.MessageContext), It.IsAny<CancellationToken>()),
             times: Times.Once);
     }
 
@@ -80,9 +80,11 @@ internal abstract class HandleAsyncBase<T, TEvent> : EventHandlerTestBase<T, TEv
     protected async Task Should_SendNotification_For_Recipients_Internal(Times notificationCount)
     {
         // Arrange
+        TEvent @event = CreateEvent();
+
         _iIamProxyServiceMock
-            .Setup(expression: x => x.GetUserNotificationAvailability(MessageContextFactoryMock.Object.Current(null),
-                _defaultOwnerId, new[]
+            .Setup(expression: x => x.GetUserNotificationAvailability(
+                It.Is<IMessageContext>(mc => mc == @event.MessageContext), _defaultOwnerId, new[]
                     {
                         _defaultParticipantId
                     }
@@ -90,15 +92,13 @@ internal abstract class HandleAsyncBase<T, TEvent> : EventHandlerTestBase<T, TEv
                     .AsReadOnly(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _defaultNotificationRecipients);
 
-        TEvent @event = CreateEvent();
-
         // Act
         await TestCandidate.HandleAsync(@event: @event, cancellationToken: default);
 
         // Assert
         _communicationProxyMock.Verify(
-            expression: x =>
-                x.SendNotificationAsync(It.IsAny<SendNotificationRequest>(), It.IsAny<CancellationToken>()),
+            expression: x => x.SendNotificationAsync(It.IsAny<SendNotificationRequest>(),
+                It.Is<IMessageContext>(mc => mc == @event.MessageContext), It.IsAny<CancellationToken>()),
             times: notificationCount);
     }
 
@@ -125,8 +125,8 @@ internal abstract class HandleAsyncBase<T, TEvent> : EventHandlerTestBase<T, TEv
             times: Times.Once);
 
         _communicationProxyMock.Verify(
-            expression: x =>
-                x.SendNotificationAsync(It.IsAny<SendNotificationRequest>(), It.IsAny<CancellationToken>()),
+            expression: x => x.SendNotificationAsync(It.IsAny<SendNotificationRequest>(),
+                It.Is<IMessageContext>(mc => mc == @event.MessageContext), It.IsAny<CancellationToken>()),
             times: notificationCount);
     }
 }

--- a/src/Communication/Expenso.Communication.Core/Application/Proxy/CommunicationProxy.cs
+++ b/src/Communication/Expenso.Communication.Core/Application/Proxy/CommunicationProxy.cs
@@ -2,6 +2,7 @@
 using Expenso.Communication.Shared;
 using Expenso.Communication.Shared.DTO.API.SendNotification;
 using Expenso.Shared.Commands.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.Communication.Core.Application.Proxy;
@@ -19,23 +20,30 @@ internal sealed class CommunicationProxy : ICommunicationProxy
                                  throw new ArgumentNullException(paramName: nameof(messageContextFactory));
     }
 
-    public async Task SendNotificationAsync(SendNotificationRequest request,
+    public async Task SendNotificationAsync(SendNotificationRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         await _commandDispatcher.SendAsync(
-            command: new SendNotificationCommand(MessageContext: _messageContextFactory.Current(), Payload: request),
+            command: new SendNotificationCommand(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.CommunicationModule)
+                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.CommunicationModule),
+                Payload: request),
             cancellationToken: cancellationToken);
     }
 
     public async Task SendNotificationsAsync(IReadOnlyCollection<SendNotificationRequest> requests,
+        IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         List<Task> sendNotificationTasks = [];
 
         foreach (SendNotificationRequest request in requests)
         {
-            sendNotificationTasks.Add(item: _commandDispatcher.SendAsync(
-                command: new SendNotificationCommand(MessageContext: _messageContextFactory.Current(),
+            sendNotificationTasks.Add(item: _commandDispatcher.SendAsync(command: new SendNotificationCommand(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.CommunicationModule)
+                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.CommunicationModule),
                     Payload: request), cancellationToken: cancellationToken));
         }
 

--- a/src/Communication/Expenso.Communication.Core/Application/Proxy/CommunicationProxy.cs
+++ b/src/Communication/Expenso.Communication.Core/Application/Proxy/CommunicationProxy.cs
@@ -25,27 +25,21 @@ internal sealed class CommunicationProxy : ICommunicationProxy
     {
         await _commandDispatcher.SendAsync(
             command: new SendNotificationCommand(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.CommunicationModule)
-                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.CommunicationModule),
-                Payload: request),
-            cancellationToken: cancellationToken);
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.CommunicationModule), Payload: request), cancellationToken: cancellationToken);
     }
 
     public async Task SendNotificationsAsync(IReadOnlyCollection<SendNotificationRequest> requests,
-        IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         List<Task> sendNotificationTasks = [];
 
-        foreach (SendNotificationRequest request in requests)
-        {
-            sendNotificationTasks.Add(item: _commandDispatcher.SendAsync(command: new SendNotificationCommand(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.CommunicationModule)
-                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.CommunicationModule),
-                    Payload: request), cancellationToken: cancellationToken));
-        }
+        sendNotificationTasks.AddRange(collection: requests.Select(selector: request =>
+            _commandDispatcher.SendAsync(
+                command: new SendNotificationCommand(
+                    MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                        moduleId: Names.CommunicationModule), Payload: request),
+                cancellationToken: cancellationToken)));
 
         await Task.WhenAll(tasks: sendNotificationTasks);
     }

--- a/src/Communication/Expenso.Communication.Core/Expenso.Communication.Core.csproj
+++ b/src/Communication/Expenso.Communication.Core/Expenso.Communication.Core.csproj
@@ -10,6 +10,7 @@
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Commands.Validation\Expenso.Shared.Commands.Validation.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Commands\Expenso.Shared.Commands.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Logging\Expenso.Shared.System.Logging.csproj"/>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Modules.Constants\Expenso.Shared.System.Modules.Constants.csproj"/>
         <ProjectReference Include="..\Expenso.Communication.Shared\Expenso.Communication.Shared.csproj"/>
     </ItemGroup>
 

--- a/src/Communication/Expenso.Communication.Shared/ICommunicationProxy.cs
+++ b/src/Communication/Expenso.Communication.Shared/ICommunicationProxy.cs
@@ -1,11 +1,13 @@
 ﻿using Expenso.Communication.Shared.DTO.API.SendNotification;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.Communication.Shared;
 
 public interface ICommunicationProxy
 {
-    public Task SendNotificationAsync(SendNotificationRequest request, CancellationToken cancellationToken = default);
+    public Task SendNotificationAsync(SendNotificationRequest request, IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default);
 
     public Task SendNotificationsAsync(IReadOnlyCollection<SendNotificationRequest> requests,
-        CancellationToken cancellationToken = default);
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
 }

--- a/src/DocumentManagement/Expenso.DocumentManagement.Core/Application/Proxy/DocumentManagementProxy.cs
+++ b/src/DocumentManagement/Expenso.DocumentManagement.Core/Application/Proxy/DocumentManagementProxy.cs
@@ -30,36 +30,30 @@ internal sealed class DocumentManagementProxy : IDocumentManagementProxy
         _queryDispatcher = queryDispatcher ?? throw new ArgumentNullException(paramName: nameof(queryDispatcher));
     }
 
-    public async Task<IEnumerable<GetFilesResponse>?> GetFilesAsync(GetFileRequest getFileRequest,
-        IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<GetFilesResponse>?> GetFilesAsync(GetFileRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
             query: new GetFilesQuery(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.DocumentManagementModule)
-                    : _messageContextFactory.FromParent(parent: messageContext,
-                        moduleId: Names.DocumentManagementModule), Payload: getFileRequest),
-            cancellationToken: cancellationToken);
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.DocumentManagementModule), Payload: request), cancellationToken: cancellationToken);
     }
 
-    public async Task UploadFilesAsync(UploadFilesRequest uploadFilesRequest, IMessageContext? messageContext = null,
+    public async Task UploadFilesAsync(UploadFilesRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
-        await _commandDispatcher.SendAsync(command: new UploadFilesCommand(
-            MessageContext: messageContext is null
-                ? _messageContextFactory.Current(moduleId: Names.DocumentManagementModule)
-                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.DocumentManagementModule),
-                Payload: uploadFilesRequest), cancellationToken: cancellationToken);
+        await _commandDispatcher.SendAsync(
+            command: new UploadFilesCommand(
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.DocumentManagementModule), Payload: request), cancellationToken: cancellationToken);
     }
 
-    public async Task DeleteFilesAsync(DeleteFilesRequest deleteFilesRequest, IMessageContext? messageContext = null,
+    public async Task DeleteFilesAsync(DeleteFilesRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
-        await _commandDispatcher.SendAsync(command: new DeleteFilesCommand(
-            MessageContext: messageContext is null
-                ? _messageContextFactory.Current(moduleId: Names.DocumentManagementModule)
-                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.DocumentManagementModule),
-                Payload: deleteFilesRequest), cancellationToken: cancellationToken);
+        await _commandDispatcher.SendAsync(
+            command: new DeleteFilesCommand(
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.DocumentManagementModule), Payload: request), cancellationToken: cancellationToken);
     }
 }

--- a/src/DocumentManagement/Expenso.DocumentManagement.Core/Application/Proxy/DocumentManagementProxy.cs
+++ b/src/DocumentManagement/Expenso.DocumentManagement.Core/Application/Proxy/DocumentManagementProxy.cs
@@ -8,6 +8,7 @@ using Expenso.DocumentManagement.Shared.DTO.API.GetFiles.Response;
 using Expenso.DocumentManagement.Shared.DTO.API.UploadFiles.Request;
 using Expenso.Shared.Commands.Dispatchers;
 using Expenso.Shared.Queries.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.DocumentManagement.Core.Application.Proxy;
@@ -30,26 +31,35 @@ internal sealed class DocumentManagementProxy : IDocumentManagementProxy
     }
 
     public async Task<IEnumerable<GetFilesResponse>?> GetFilesAsync(GetFileRequest getFileRequest,
+        IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetFilesQuery(MessageContext: _messageContextFactory.Current(), Payload: getFileRequest),
+            query: new GetFilesQuery(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.DocumentManagementModule)
+                    : _messageContextFactory.FromParent(parent: messageContext,
+                        moduleId: Names.DocumentManagementModule), Payload: getFileRequest),
             cancellationToken: cancellationToken);
     }
 
-    public async Task UploadFilesAsync(UploadFilesRequest uploadFilesRequest,
+    public async Task UploadFilesAsync(UploadFilesRequest uploadFilesRequest, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
-        await _commandDispatcher.SendAsync(
-            command: new UploadFilesCommand(MessageContext: _messageContextFactory.Current(),
+        await _commandDispatcher.SendAsync(command: new UploadFilesCommand(
+            MessageContext: messageContext is null
+                ? _messageContextFactory.Current(moduleId: Names.DocumentManagementModule)
+                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.DocumentManagementModule),
                 Payload: uploadFilesRequest), cancellationToken: cancellationToken);
     }
 
-    public async Task DeleteFilesAsync(DeleteFilesRequest deleteFilesRequest,
+    public async Task DeleteFilesAsync(DeleteFilesRequest deleteFilesRequest, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
-        await _commandDispatcher.SendAsync(
-            command: new DeleteFilesCommand(MessageContext: _messageContextFactory.Current(),
+        await _commandDispatcher.SendAsync(command: new DeleteFilesCommand(
+            MessageContext: messageContext is null
+                ? _messageContextFactory.Current(moduleId: Names.DocumentManagementModule)
+                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.DocumentManagementModule),
                 Payload: deleteFilesRequest), cancellationToken: cancellationToken);
     }
 }

--- a/src/DocumentManagement/Expenso.DocumentManagement.Core/Expenso.DocumentManagement.Core.csproj
+++ b/src/DocumentManagement/Expenso.DocumentManagement.Core/Expenso.DocumentManagement.Core.csproj
@@ -11,6 +11,7 @@
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Commands\Expenso.Shared.Commands.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Queries\Expenso.Shared.Queries.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Configuration\Expenso.Shared.System.Configuration.csproj"/>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Modules.Constants\Expenso.Shared.System.Modules.Constants.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Types\Expenso.Shared.System.Types.csproj"/>
         <ProjectReference Include="..\Expenso.DocumentManagement.Shared\Expenso.DocumentManagement.Shared.csproj"/>
     </ItemGroup>

--- a/src/DocumentManagement/Expenso.DocumentManagement.Shared/Expenso.DocumentManagement.Shared.csproj
+++ b/src/DocumentManagement/Expenso.DocumentManagement.Shared/Expenso.DocumentManagement.Shared.csproj
@@ -17,4 +17,8 @@
         <PackageReference Include="Scrutor" Version="4.2.2"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Types\Expenso.Shared.System.Types.csproj"/>
+    </ItemGroup>
+
 </Project>

--- a/src/DocumentManagement/Expenso.DocumentManagement.Shared/IDocumentManagementProxy.cs
+++ b/src/DocumentManagement/Expenso.DocumentManagement.Shared/IDocumentManagementProxy.cs
@@ -2,15 +2,18 @@ using Expenso.DocumentManagement.Shared.DTO.API.DeleteFiles.Request;
 using Expenso.DocumentManagement.Shared.DTO.API.GetFiles.Request;
 using Expenso.DocumentManagement.Shared.DTO.API.GetFiles.Response;
 using Expenso.DocumentManagement.Shared.DTO.API.UploadFiles.Request;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.DocumentManagement.Shared;
 
 public interface IDocumentManagementProxy
 {
     Task<IEnumerable<GetFilesResponse>?> GetFilesAsync(GetFileRequest getFileRequest,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
+
+    Task UploadFilesAsync(UploadFilesRequest uploadFilesRequest, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default);
 
-    Task UploadFilesAsync(UploadFilesRequest uploadFilesRequest, CancellationToken cancellationToken = default);
-
-    Task DeleteFilesAsync(DeleteFilesRequest deleteFilesRequest, CancellationToken cancellationToken = default);
+    Task DeleteFilesAsync(DeleteFilesRequest deleteFilesRequest, IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/IAM/Expenso.IAM.Core/Application/Proxy/IamProxy.cs
+++ b/src/IAM/Expenso.IAM.Core/Application/Proxy/IamProxy.cs
@@ -31,9 +31,7 @@ internal sealed class IamProxy : IIamProxy
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUserByIdQuery(MessageContext:             messageContext is null
-            ? _messageContextFactory.Current(moduleId: Names.IamModule)
-            : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
+            query: new GetUserByIdQuery(MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 
@@ -41,9 +39,7 @@ internal sealed class IamProxy : IIamProxy
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUserByEmailQuery(            MessageContext: messageContext is null
-                ? _messageContextFactory.Current(moduleId: Names.IamModule)
-                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
+            query: new GetUserByEmailQuery(            MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 
@@ -51,9 +47,7 @@ internal sealed class IamProxy : IIamProxy
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUsersQuery(            MessageContext: messageContext is null
-                ? _messageContextFactory.Current(moduleId: Names.IamModule)
-                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
+            query: new GetUsersQuery(           MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 }

--- a/src/IAM/Expenso.IAM.Core/Application/Proxy/IamProxy.cs
+++ b/src/IAM/Expenso.IAM.Core/Application/Proxy/IamProxy.cs
@@ -9,6 +9,7 @@ using Expenso.IAM.Shared.DTO.GetUserById.Response;
 using Expenso.IAM.Shared.DTO.GetUsers.Request;
 using Expenso.IAM.Shared.DTO.GetUsers.Response;
 using Expenso.Shared.Queries.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.IAM.Core.Application.Proxy;
@@ -26,27 +27,33 @@ internal sealed class IamProxy : IIamProxy
         _queryDispatcher = queryDispatcher ?? throw new ArgumentNullException(paramName: nameof(queryDispatcher));
     }
 
-    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request,
+    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUserByIdQuery(MessageContext: _messageContextFactory.Current(), Payload: request),
+            query: new GetUserByIdQuery(MessageContext:             messageContext is null
+            ? _messageContextFactory.Current(moduleId: Names.IamModule)
+            : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 
-    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,
+    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUserByEmailQuery(MessageContext: _messageContextFactory.Current(), Payload: request),
+            query: new GetUserByEmailQuery(            MessageContext: messageContext is null
+                ? _messageContextFactory.Current(moduleId: Names.IamModule)
+                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 
-    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,
+    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUsersQuery(MessageContext: _messageContextFactory.Current(), Payload: request),
+            query: new GetUsersQuery(            MessageContext: messageContext is null
+                ? _messageContextFactory.Current(moduleId: Names.IamModule)
+                : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 }

--- a/src/IAM/Expenso.IAM.Core/Application/Proxy/IamProxy.cs
+++ b/src/IAM/Expenso.IAM.Core/Application/Proxy/IamProxy.cs
@@ -27,27 +27,30 @@ internal sealed class IamProxy : IIamProxy
         _queryDispatcher = queryDispatcher ?? throw new ArgumentNullException(paramName: nameof(queryDispatcher));
     }
 
-    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request, IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUserByIdQuery(MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
-            cancellationToken: cancellationToken);
+            query: new GetUserByIdQuery(
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule),
+                Payload: request), cancellationToken: cancellationToken);
     }
 
-    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request, IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUserByEmailQuery(            MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
-            cancellationToken: cancellationToken);
+            query: new GetUserByEmailQuery(
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule),
+                Payload: request), cancellationToken: cancellationToken);
     }
 
-    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request, IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+    public async Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetUsersQuery(           MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule), Payload: request),
-            cancellationToken: cancellationToken);
+            query: new GetUsersQuery(
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.IamModule),
+                Payload: request), cancellationToken: cancellationToken);
     }
 }

--- a/src/IAM/Expenso.IAM.Core/Application/Users/Read/Queries/GetUserByEmail/GetUserByEmailQueryHandler.cs
+++ b/src/IAM/Expenso.IAM.Core/Application/Users/Read/Queries/GetUserByEmail/GetUserByEmailQueryHandler.cs
@@ -16,7 +16,6 @@ internal sealed class GetUserByEmailQueryHandler : IQueryHandler<GetUserByEmailQ
     public async Task<GetUserByEmailResponse?> HandleAsync(GetUserByEmailQuery query,
         CancellationToken cancellationToken)
     {
-        return await _userService.GetUserByEmailAsync(request: query.Payload,
-            cancellationToken: cancellationToken);
+        return await _userService.GetUserByEmailAsync(request: query.Payload, cancellationToken: cancellationToken);
     }
 }

--- a/src/IAM/Expenso.IAM.Core/Expenso.IAM.Core.csproj
+++ b/src/IAM/Expenso.IAM.Core/Expenso.IAM.Core.csproj
@@ -17,6 +17,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Configuration\Expenso.Shared.System.Configuration.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Queries\Expenso.Shared.Queries.csproj"/>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Modules.Constants\Expenso.Shared.System.Modules.Constants.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Types\Expenso.Shared.System.Types.csproj"/>
         <ProjectReference Include="..\Expenso.IAM.Shared\Expenso.IAM.Shared.csproj"/>
     </ItemGroup>

--- a/src/IAM/Expenso.IAM.Shared/IIamProxy.cs
+++ b/src/IAM/Expenso.IAM.Shared/IIamProxy.cs
@@ -2,9 +2,9 @@ using Expenso.IAM.Shared.DTO.GetUserByEmail.Request;
 using Expenso.IAM.Shared.DTO.GetUserByEmail.Response;
 using Expenso.IAM.Shared.DTO.GetUserById.Request;
 using Expenso.IAM.Shared.DTO.GetUserById.Response;
-using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.IAM.Shared.DTO.GetUsers.Request;
 using Expenso.IAM.Shared.DTO.GetUsers.Response;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.IAM.Shared;
 
@@ -13,9 +13,9 @@ public interface IIamProxy
     Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request, IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default);
 
-    Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default);
+    Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request, IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default);
+    Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
 }

--- a/src/IAM/Expenso.IAM.Shared/IIamProxy.cs
+++ b/src/IAM/Expenso.IAM.Shared/IIamProxy.cs
@@ -2,6 +2,7 @@ using Expenso.IAM.Shared.DTO.GetUserByEmail.Request;
 using Expenso.IAM.Shared.DTO.GetUserByEmail.Response;
 using Expenso.IAM.Shared.DTO.GetUserById.Request;
 using Expenso.IAM.Shared.DTO.GetUserById.Response;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.IAM.Shared.DTO.GetUsers.Request;
 using Expenso.IAM.Shared.DTO.GetUsers.Response;
 
@@ -9,11 +10,12 @@ namespace Expenso.IAM.Shared;
 
 public interface IIamProxy
 {
-    Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request, CancellationToken cancellationToken);
+    Task<GetUserByIdResponse?> GetUserByIdAsync(GetUserByIdRequest request, IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default);
 
-    Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,
-        CancellationToken cancellationToken);
+    Task<GetUserByEmailResponse?> GetUserByEmailAsync(GetUserByEmailRequest request,IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default);
 
-    Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request,
-        CancellationToken cancellationToken);
+    Task<IReadOnlyCollection<GetUsersResponse>?> GetUsersAsync(GetUsersRequest request, IMessageContext? messageContext = null,
+        CancellationToken cancellationToken = default);
 }

--- a/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/GetUserByEmailAsync.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/GetUserByEmailAsync.cs
@@ -31,7 +31,7 @@ internal sealed class GetUserByEmailAsync : IamProxyTestBase
     }
 
     [Test]
-    public void Should_ReturnNull_When_UserDoesNotExists()
+    public void Should_ThrowsNotFoundException_When_UserDoesNotExists()
     {
         // Arrange
         const string email = "email1@email.com";

--- a/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/GetUserByIdAsync.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/GetUserByIdAsync.cs
@@ -31,7 +31,7 @@ internal sealed class GetUserByIdAsync : IamProxyTestBase
     }
 
     [Test]
-    public void Should_ReturnNull_When_UserDoesNotExists()
+    public void Should_ThrowsNotFoundException_When_UserDoesNotExists()
     {
         // Arrange
         string userId = Guid.NewGuid().ToString();

--- a/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/GetUsersAsync.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/GetUsersAsync.cs
@@ -1,0 +1,45 @@
+﻿using Expenso.IAM.Core.Application.Users.Read.Queries.GetUsers;
+using Expenso.IAM.Shared.DTO.GetUsers.Request;
+using Expenso.IAM.Shared.DTO.GetUsers.Response;
+
+namespace Expenso.IAM.Tests.UnitTests.Users.Proxy.IamProxy;
+
+[TestFixture]
+internal sealed class GetUsersAsync : IamProxyTestBase
+{
+    [Test]
+    public async Task Should_ReturnUser_When_UserExists()
+    {
+        // Arrange
+        _queryDispatcherMock
+            .Setup(expression: x => x.QueryAsync(It.IsAny<GetUsersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(value: _getUsersResponse);
+
+        // Act
+        IReadOnlyCollection<GetUsersResponse>? getUsersResponse = await TestCandidate.GetUsersAsync(
+            request: new GetUsersRequest(), cancellationToken: It.IsAny<CancellationToken>());
+
+        // Assert
+        getUsersResponse.Should().NotBeNull();
+        getUsersResponse.Should().BeEquivalentTo(expectation: _getUsersResponse);
+
+        _queryDispatcherMock.Verify(
+            expression: x => x.QueryAsync(It.IsAny<GetUsersQuery>(), It.IsAny<CancellationToken>()), times: Times.Once);
+    }
+
+    [Test]
+    public async Task Should_ReturnNull_When_UserDoesNotExists()
+    {
+        // Arrange
+        _queryDispatcherMock
+            .Setup(expression: x => x.QueryAsync(It.IsAny<GetUsersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(value: null);
+
+        // Act
+        IReadOnlyCollection<GetUsersResponse>? getUsersResponse = await TestCandidate.GetUsersAsync(
+            request: new GetUsersRequest(), cancellationToken: It.IsAny<CancellationToken>());
+
+        // Assert
+        getUsersResponse.Should().BeNull();
+    }
+}

--- a/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/IamProxyTestBase.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Proxy/IamProxy/IamProxyTestBase.cs
@@ -1,8 +1,10 @@
 using Expenso.IAM.Core.Application.Users.Read.Queries.GetUserByEmail.DTO.Maps;
 using Expenso.IAM.Core.Application.Users.Read.Queries.GetUserById.DTO.Maps;
+using Expenso.IAM.Core.Application.Users.Read.Queries.GetUsers.DTO.Maps;
 using Expenso.IAM.Shared;
 using Expenso.IAM.Shared.DTO.GetUserByEmail.Response;
 using Expenso.IAM.Shared.DTO.GetUserById.Response;
+using Expenso.IAM.Shared.DTO.GetUsers.Response;
 using Expenso.Shared.Queries.Dispatchers;
 
 using Keycloak.AuthServices.Sdk.Admin.Models;
@@ -29,6 +31,7 @@ internal abstract class IamProxyTestBase : TestBase<IIamProxy>
 
         _getUserByIdResponse = GetUserByIdResponseMap.MapTo(user: user);
         _getUserByEmailResponse = GetUserByEmailResponseMap.MapTo(user: user);
+        _getUsersResponse = [GetUsersResponseMap.MapTo(user: user)];
         _queryDispatcherMock = new Mock<IQueryDispatcher>();
 
         TestCandidate = new Core.Application.Proxy.IamProxy(queryDispatcher: _queryDispatcherMock.Object,
@@ -37,6 +40,7 @@ internal abstract class IamProxyTestBase : TestBase<IIamProxy>
 
     protected GetUserByIdResponse _getUserByIdResponse = null!;
     protected GetUserByEmailResponse _getUserByEmailResponse = null!;
+    protected IReadOnlyCollection<GetUsersResponse> _getUsersResponse = null!;
     protected Mock<IQueryDispatcher> _queryDispatcherMock = null!;
     protected string _userEmail = null!;
     protected string _userId = null!;

--- a/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Queries/GetUser/GetUserByIdQueryHandler/GetUserByIdQueryHandlerTestBase.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Queries/GetUser/GetUserByIdQueryHandler/GetUserByIdQueryHandlerTestBase.cs
@@ -9,8 +9,7 @@ using Keycloak.AuthServices.Sdk.Admin.Models;
 namespace Expenso.IAM.Tests.UnitTests.Users.Queries.GetUser.GetUserByIdQueryHandler;
 
 [TestFixture]
-internal abstract class GetUserByIdQueryHandlerTestBase : TestBase<
-    GetUserByIdQueryQueryHandler>
+internal abstract class GetUserByIdQueryHandlerTestBase : TestBase<GetUserByIdQueryQueryHandler>
 {
     [SetUp]
     public void SetUp()
@@ -29,10 +28,7 @@ internal abstract class GetUserByIdQueryHandlerTestBase : TestBase<
         _getUserByIdResponse = GetUserByIdResponseMap.MapTo(user: user);
         _userServiceMock = new Mock<IUserService>();
         _messageContextMock = new Mock<IMessageContext>();
-
-        TestCandidate =
-            new GetUserByIdQueryQueryHandler(
-                userService: _userServiceMock.Object);
+        TestCandidate = new GetUserByIdQueryQueryHandler(userService: _userServiceMock.Object);
     }
 
     protected GetUserByIdResponse _getUserByIdResponse = null!;

--- a/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Services/Acl/Keycloak/GetUserByEmailAsync.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.UnitTests/Users/Services/Acl/Keycloak/GetUserByEmailAsync.cs
@@ -49,8 +49,7 @@ internal sealed class GetUserByEmailAsync : UserServiceTestBase
 
         // Act
         Func<Task> action = async () => await TestCandidate.GetUserByEmailAsync(
-            request: new GetUserByEmailRequest(Email: email),
-                cancellationToken: It.IsAny<CancellationToken>());
+            request: new GetUserByEmailRequest(Email: email), cancellationToken: It.IsAny<CancellationToken>());
 
         // Assert
         action

--- a/src/Shared/Expenso.Shared.System.Logging/LoggerService.cs
+++ b/src/Shared/Expenso.Shared.System.Logging/LoggerService.cs
@@ -74,8 +74,7 @@ internal sealed class LoggerService<T> : ILoggerService<T> where T : class
 
     private List<KeyValuePair<string, object>> GetLogParameters(IMessageContext? messageContext)
     {
-        List<KeyValuePair<string, object>> parameters =
-            [new KeyValuePair<string, object>(key: "AppId", value: _applicationSettings.InstanceId!)];
+        List<KeyValuePair<string, object>> parameters = [new(key: "AppId", value: _applicationSettings.InstanceId!)];
 
         if (!string.IsNullOrWhiteSpace(value: _applicationSettings.Name))
         {

--- a/src/Shared/Expenso.Shared.System.Types/Expenso.Shared.System.Types.csproj
+++ b/src/Shared/Expenso.Shared.System.Types/Expenso.Shared.System.Types.csproj
@@ -11,6 +11,7 @@
         <InternalsVisibleTo Include="Expenso.Shared.Tests.UnitTests"/>
         <InternalsVisibleTo Include="Expenso.Shared.Tests.Utils.UnitTests"/>
         <InternalsVisibleTo Include="Expenso.Shared.Tests.Utils.ArchTests"/>
+        <InternalsVisibleTo Include="Expenso.Api.Tests.E2E"/>
         <InternalsVisibleTo Include="DynamicProxyGenAssembly2"/>
     </ItemGroup>
 

--- a/src/Shared/Expenso.Shared.System.Types/Messages/Interfaces/IMessageContextFactory.cs
+++ b/src/Shared/Expenso.Shared.System.Types/Messages/Interfaces/IMessageContextFactory.cs
@@ -4,5 +4,5 @@ public interface IMessageContextFactory
 {
     IMessageContext Current(Guid? messageId = null, string? moduleId = null);
 
-    IMessageContext FromParent(IMessageContext parent, string? moduleId, Guid? messageId = null);
+    IMessageContext FromParent(IMessageContext? parent, string? moduleId, Guid? messageId = null);
 }

--- a/src/Shared/Expenso.Shared.System.Types/Messages/Interfaces/IMessageContextFactory.cs
+++ b/src/Shared/Expenso.Shared.System.Types/Messages/Interfaces/IMessageContextFactory.cs
@@ -2,5 +2,7 @@ namespace Expenso.Shared.System.Types.Messages.Interfaces;
 
 public interface IMessageContextFactory
 {
-    IMessageContext Current(Guid? messageId = null);
+    IMessageContext Current(Guid? messageId = null, string? moduleId = null);
+
+    IMessageContext FromParent(IMessageContext parent, string? moduleId, Guid? messageId = null);
 }

--- a/src/Shared/Expenso.Shared.System.Types/Messages/MessageContext.cs
+++ b/src/Shared/Expenso.Shared.System.Types/Messages/MessageContext.cs
@@ -1,5 +1,3 @@
-using Expenso.Shared.System.Types.Clock;
-using Expenso.Shared.System.Types.ExecutionContext.Models;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 
 namespace Expenso.Shared.System.Types.Messages;
@@ -19,19 +17,6 @@ public sealed record MessageContext : IMessageContext
         RequestedBy = requestedBy;
         Timestamp = timestamp;
         ModuleId = module;
-    }
-
-    internal MessageContext(IExecutionContext? executionContext, IClock clock, Guid? messageId)
-    {
-        MessageId = messageId ?? Guid.NewGuid();
-        ModuleId = executionContext?.ModuleId ?? "Unknown";
-        CorrelationId = executionContext?.CorrelationId ?? Guid.Empty;
-
-        RequestedBy = Guid.TryParse(input: executionContext?.UserContext?.UserId, result: out Guid id)
-            ? id
-            : Guid.Empty;
-
-        Timestamp = clock.UtcNow;
     }
 
     public string? ModuleId { get; init; }

--- a/src/Shared/Expenso.Shared.System.Types/Messages/MessageContextFactory.cs
+++ b/src/Shared/Expenso.Shared.System.Types/Messages/MessageContextFactory.cs
@@ -30,17 +30,27 @@ internal sealed class MessageContextFactory : IMessageContextFactory
             ? id
             : Guid.Empty;
 
+        string resolvedModuleId = string.IsNullOrWhiteSpace(value: moduleId)
+            ? string.IsNullOrWhiteSpace(value: executionContext?.ModuleId) ? "Unknown" : executionContext.ModuleId
+            : moduleId;
+
         return new MessageContext(messageId: messageId ?? Guid.NewGuid(),
             correlationId: executionContext?.CorrelationId ?? Guid.Empty, requestedBy: requestedBy,
-            timestamp: clock.UtcNow, module: moduleId ?? executionContext?.ModuleId ?? "Unknown");
+            timestamp: clock.UtcNow, module: resolvedModuleId);
     }
 
-    public IMessageContext FromParent(IMessageContext parent, string? moduleId, Guid? messageId = null)
+    public IMessageContext FromParent(IMessageContext? parent, string? moduleId, Guid? messageId = null)
     {
+        if (parent is null)
+        {
+            return Current(messageId: messageId, moduleId: moduleId);
+        }
+
         using IServiceScope scope = _serviceProvider.CreateScope();
         IClock clock = scope.ServiceProvider.GetRequiredService<IClock>();
 
         return new MessageContext(messageId: messageId ?? Guid.NewGuid(), correlationId: parent.CorrelationId,
-            requestedBy: parent.RequestedBy, timestamp: clock.UtcNow, module: moduleId ?? "Unknown");
+            requestedBy: parent.RequestedBy, timestamp: clock.UtcNow,
+            module: string.IsNullOrWhiteSpace(value: moduleId) ? "Unknown" : moduleId);
     }
 }

--- a/src/Shared/Expenso.Shared.System.Types/Messages/MessageContextFactory.cs
+++ b/src/Shared/Expenso.Shared.System.Types/Messages/MessageContextFactory.cs
@@ -1,5 +1,6 @@
 using Expenso.Shared.System.Types.Clock;
 using Expenso.Shared.System.Types.ExecutionContext;
+using Expenso.Shared.System.Types.ExecutionContext.Models;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 
 using Microsoft.Extensions.DependencyInjection;
@@ -15,7 +16,7 @@ internal sealed class MessageContextFactory : IMessageContextFactory
         _serviceProvider = serviceProvider ?? throw new ArgumentNullException(paramName: nameof(serviceProvider));
     }
 
-    public IMessageContext Current(Guid? messageId = null)
+    public IMessageContext Current(Guid? messageId = null, string? moduleId = null)
     {
         using IServiceScope scope = _serviceProvider.CreateScope();
 
@@ -23,7 +24,23 @@ internal sealed class MessageContextFactory : IMessageContextFactory
             scope.ServiceProvider.GetRequiredService<IExecutionContextAccessor>();
 
         IClock clock = scope.ServiceProvider.GetRequiredService<IClock>();
+        IExecutionContext? executionContext = executionContextAccessor.Get();
 
-        return new MessageContext(executionContext: executionContextAccessor.Get(), clock: clock, messageId: messageId);
+        Guid requestedBy = Guid.TryParse(input: executionContext?.UserContext?.UserId, result: out Guid id)
+            ? id
+            : Guid.Empty;
+
+        return new MessageContext(messageId: messageId ?? Guid.NewGuid(),
+            correlationId: executionContext?.CorrelationId ?? Guid.Empty, requestedBy: requestedBy,
+            timestamp: clock.UtcNow, module: moduleId ?? executionContext?.ModuleId ?? "Unknown");
+    }
+
+    public IMessageContext FromParent(IMessageContext parent, string? moduleId, Guid? messageId = null)
+    {
+        using IServiceScope scope = _serviceProvider.CreateScope();
+        IClock clock = scope.ServiceProvider.GetRequiredService<IClock>();
+
+        return new MessageContext(messageId: messageId ?? Guid.NewGuid(), correlationId: parent.CorrelationId,
+            requestedBy: parent.RequestedBy, timestamp: clock.UtcNow, module: moduleId ?? "Unknown");
     }
 }

--- a/src/Shared/Expenso.Shared.System.Types/Messages/MessageContextFactory.cs
+++ b/src/Shared/Expenso.Shared.System.Types/Messages/MessageContextFactory.cs
@@ -30,9 +30,11 @@ internal sealed class MessageContextFactory : IMessageContextFactory
             ? id
             : Guid.Empty;
 
-        string resolvedModuleId = string.IsNullOrWhiteSpace(value: moduleId)
-            ? string.IsNullOrWhiteSpace(value: executionContext?.ModuleId) ? "Unknown" : executionContext.ModuleId
-            : moduleId;
+        string executionContextModuleId = !string.IsNullOrWhiteSpace(value: executionContext?.ModuleId)
+            ? executionContext.ModuleId
+            : "Unknown";
+
+        string resolvedModuleId = !string.IsNullOrWhiteSpace(value: moduleId) ? moduleId : executionContextModuleId;
 
         return new MessageContext(messageId: messageId ?? Guid.NewGuid(),
             correlationId: executionContext?.CorrelationId ?? Guid.Empty, requestedBy: requestedBy,

--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/TestBase.cs
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/TestBase.cs
@@ -12,7 +12,10 @@ public abstract class TestBase<T> where T : class
     public virtual void OneTimeSetUp()
     {
         MessageContextFactoryMock = new Mock<IMessageContextFactory>();
-        MessageContextFactoryMock.Setup(expression: x => x.Current(It.IsAny<Guid?>())).Returns(value: _messageContext);
+
+        MessageContextFactoryMock
+            .Setup(expression: x => x.Current(It.IsAny<Guid?>(), It.IsAny<string?>()))
+            .Returns(value: _messageContext);
     }
 
     [OneTimeTearDown]

--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/TestBase.cs
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/TestBase.cs
@@ -15,7 +15,8 @@ public abstract class TestBase<T> where T : class
 
         MessageContextFactoryMock
             .Setup(expression: x => x.Current(It.IsAny<Guid?>(), It.IsAny<string?>()))
-            .Returns(value: _messageContext);
+            .Returns(value: new MessageContext(messageId: Guid.NewGuid(), correlationId: Guid.NewGuid(),
+                requestedBy: Guid.NewGuid(), timestamp: DateTimeOffset.Now, module: "TestModule"));
     }
 
     [OneTimeTearDown]
@@ -24,9 +25,6 @@ public abstract class TestBase<T> where T : class
         MessageContextFactoryMock = null!;
         TestCandidate = null!;
     }
-
-    private readonly MessageContext _messageContext = new(messageId: Guid.NewGuid(), correlationId: Guid.NewGuid(),
-        requestedBy: Guid.NewGuid(), timestamp: DateTimeOffset.Now, module: "TestModule");
 
     protected Mock<IMessageContextFactory> MessageContextFactoryMock { get; set; } = null!;
 

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/Proxy/TimeManagementProxy.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/Proxy/TimeManagementProxy.cs
@@ -1,4 +1,5 @@
 ﻿using Expenso.Shared.Commands.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.TimeManagement.Core.Application.Jobs.Write.RegisterJob;
 using Expenso.TimeManagement.Shared;
@@ -21,10 +22,14 @@ internal sealed class TimeManagementProxy : ITimeManagementProxy
     }
 
     public async Task<RegisterJobEntryResponse?> RegisterJobEntry(RegisterJobEntryRequest jobEntryRequest,
+        IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         return await _commandDispatcher.SendAsync<RegisterJobEntryCommand, RegisterJobEntryResponse>(
-            command: new RegisterJobEntryCommand(MessageContext: _messageContextFactory.Current(),
+            command: new RegisterJobEntryCommand(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.TimeManagementModule)
+                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.TimeManagementModule),
                 Payload: jobEntryRequest), cancellationToken: cancellationToken);
     }
 }

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/Proxy/TimeManagementProxy.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/Proxy/TimeManagementProxy.cs
@@ -22,8 +22,7 @@ internal sealed class TimeManagementProxy : ITimeManagementProxy
     }
 
     public async Task<RegisterJobEntryResponse?> RegisterJobEntry(RegisterJobEntryRequest request,
-        IMessageContext? messageContext = null,
-        CancellationToken cancellationToken = default)
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _commandDispatcher.SendAsync<RegisterJobEntryCommand, RegisterJobEntryResponse>(
             command: new RegisterJobEntryCommand(

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/Proxy/TimeManagementProxy.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/Proxy/TimeManagementProxy.cs
@@ -21,15 +21,13 @@ internal sealed class TimeManagementProxy : ITimeManagementProxy
                                  throw new ArgumentNullException(paramName: nameof(messageContextFactory));
     }
 
-    public async Task<RegisterJobEntryResponse?> RegisterJobEntry(RegisterJobEntryRequest jobEntryRequest,
+    public async Task<RegisterJobEntryResponse?> RegisterJobEntry(RegisterJobEntryRequest request,
         IMessageContext? messageContext = null,
         CancellationToken cancellationToken = default)
     {
         return await _commandDispatcher.SendAsync<RegisterJobEntryCommand, RegisterJobEntryResponse>(
             command: new RegisterJobEntryCommand(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.TimeManagementModule)
-                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.TimeManagementModule),
-                Payload: jobEntryRequest), cancellationToken: cancellationToken);
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.TimeManagementModule), Payload: request), cancellationToken: cancellationToken);
     }
 }

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Expenso.TimeManagement.Core.csproj
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Expenso.TimeManagement.Core.csproj
@@ -14,6 +14,7 @@
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Database.EfCore.Npsql\Expenso.Shared.Database.EfCore.Npsql.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Integration.Events\Expenso.Shared.Integration.Events.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Integration.MessageBroker\Expenso.Shared.Integration.MessageBroker.csproj"/>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Modules.Constants\Expenso.Shared.System.Modules.Constants.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Serialization\Expenso.Shared.System.Serialization.csproj"/>
         <ProjectReference Include="..\Expenso.TimeManagement.Shared\Expenso.TimeManagement.Shared.csproj"/>
     </ItemGroup>

--- a/src/TimeManagement/Expenso.TimeManagement.Shared/Expenso.TimeManagement.Shared.csproj
+++ b/src/TimeManagement/Expenso.TimeManagement.Shared/Expenso.TimeManagement.Shared.csproj
@@ -17,4 +17,8 @@
         <PackageReference Include="Scrutor" Version="4.2.2"/>
     </ItemGroup>
 
+    <ItemGroup>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Types\Expenso.Shared.System.Types.csproj"/>
+    </ItemGroup>
+
 </Project>

--- a/src/TimeManagement/Expenso.TimeManagement.Shared/ITimeManagementProxy.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Shared/ITimeManagementProxy.cs
@@ -1,3 +1,4 @@
+using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.TimeManagement.Shared.DTO.Request;
 using Expenso.TimeManagement.Shared.DTO.Response;
 
@@ -6,5 +7,5 @@ namespace Expenso.TimeManagement.Shared;
 public interface ITimeManagementProxy
 {
     Task<RegisterJobEntryResponse?> RegisterJobEntry(RegisterJobEntryRequest jobEntryRequest,
-        CancellationToken cancellationToken = default);
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
@@ -34,11 +34,8 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
     {
         return await _queryDispatcher.QueryAsync(
             query: new GetPreferencesQuery(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.UserPreferencesModule)
-                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.UserPreferencesModule),
-                Payload: request),
-            cancellationToken: cancellationToken);
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.UserPreferencesModule), Payload: request), cancellationToken: cancellationToken);
     }
 
     public async Task<CreatePreferenceResponse?> CreatePreferencesAsync(CreatePreferenceRequest request,
@@ -46,10 +43,7 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
     {
         return await _commandDispatcher.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
             command: new CreatePreferenceCommand(
-                MessageContext: messageContext is null
-                    ? _messageContextFactory.Current(moduleId: Names.UserPreferencesModule)
-                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.UserPreferencesModule),
-                Payload: request),
-            cancellationToken: cancellationToken);
+                MessageContext: _messageContextFactory.FromParent(parent: messageContext,
+                    moduleId: Names.UserPreferencesModule), Payload: request), cancellationToken: cancellationToken);
     }
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
@@ -1,5 +1,6 @@
 using Expenso.Shared.Commands.Dispatchers;
 using Expenso.Shared.Queries.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferences;
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.CreatePreference;
@@ -29,18 +30,26 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
     }
 
     public async Task<GetPreferencesResponse?> GetPreferences(GetPreferencesRequest request,
-        CancellationToken cancellationToken = default)
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _queryDispatcher.QueryAsync(
-            query: new GetPreferencesQuery(MessageContext: _messageContextFactory.Current(), Payload: request),
+            query: new GetPreferencesQuery(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.UserPreferencesModule)
+                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.UserPreferencesModule),
+                Payload: request),
             cancellationToken: cancellationToken);
     }
 
     public async Task<CreatePreferenceResponse?> CreatePreferencesAsync(CreatePreferenceRequest request,
-        CancellationToken cancellationToken = default)
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default)
     {
         return await _commandDispatcher.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
-            command: new CreatePreferenceCommand(MessageContext: _messageContextFactory.Current(), Payload: request),
+            command: new CreatePreferenceCommand(
+                MessageContext: messageContext is null
+                    ? _messageContextFactory.Current(moduleId: Names.UserPreferencesModule)
+                    : _messageContextFactory.FromParent(parent: messageContext, moduleId: Names.UserPreferencesModule),
+                Payload: request),
             cancellationToken: cancellationToken);
     }
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Expenso.UserPreferences.Core.csproj
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Expenso.UserPreferences.Core.csproj
@@ -17,6 +17,7 @@
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Integration.MessageBroker\Expenso.Shared.Integration.MessageBroker.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.Queries\Expenso.Shared.Queries.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Expressions\Expenso.Shared.System.Expressions.csproj"/>
+        <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Modules.Constants\Expenso.Shared.System.Modules.Constants.csproj"/>
         <ProjectReference Include="..\..\Shared\Expenso.Shared.System.Types\Expenso.Shared.System.Types.csproj"/>
         <ProjectReference Include="..\Expenso.UserPreferences.Shared\Expenso.UserPreferences.Shared.csproj"/>
     </ItemGroup>

--- a/src/UserPreferences/Expenso.UserPreferences.Shared/IUserPreferencesProxy.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Shared/IUserPreferencesProxy.cs
@@ -1,3 +1,4 @@
+using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Request;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Response;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Request;
@@ -8,8 +9,8 @@ namespace Expenso.UserPreferences.Shared;
 public interface IUserPreferencesProxy
 {
     Task<GetPreferencesResponse?> GetPreferences(GetPreferencesRequest getPreferenceRequest,
-        CancellationToken cancellationToken = default);
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
 
     Task<CreatePreferenceResponse?> CreatePreferencesAsync(CreatePreferenceRequest request,
-        CancellationToken cancellationToken = default);
+        IMessageContext? messageContext = null, CancellationToken cancellationToken = default);
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
@@ -16,7 +16,8 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
         _commandDispatcherMock
             .Setup(expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
                 new CreatePreferenceCommand(
-                    MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                        It.IsAny<Guid>()),
                     createPreferenceRequest),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _createPreferenceResponse);
@@ -31,7 +32,8 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
 
         _commandDispatcherMock.Verify(
             expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(new CreatePreferenceCommand(
-                MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+                MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                    It.IsAny<Guid>()),
                     new CreatePreferenceRequest(_userId)), It.IsAny<CancellationToken>()), times: Times.Once);
     }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
@@ -15,7 +15,9 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
 
         _commandDispatcherMock
             .Setup(expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
-                new CreatePreferenceCommand(MessageContextFactoryMock.Object.Current(null), createPreferenceRequest),
+                new CreatePreferenceCommand(
+                    MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+                    createPreferenceRequest),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _createPreferenceResponse);
 
@@ -28,8 +30,8 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
         preference.Should().BeEquivalentTo(expectation: _createPreferenceResponse);
 
         _commandDispatcherMock.Verify(
-            expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
-                new CreatePreferenceCommand(MessageContextFactoryMock.Object.Current(null),
+            expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(new CreatePreferenceCommand(
+                MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
                     new CreatePreferenceRequest(_userId)), It.IsAny<CancellationToken>()), times: Times.Once);
     }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
@@ -17,9 +17,7 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
             .Setup(expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
                 new CreatePreferenceCommand(
                     MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
-                        It.IsAny<Guid>()),
-                    createPreferenceRequest),
-                It.IsAny<CancellationToken>()))
+                        It.IsAny<Guid>()), createPreferenceRequest), It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _createPreferenceResponse);
 
         // Act
@@ -31,9 +29,10 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
         preference.Should().BeEquivalentTo(expectation: _createPreferenceResponse);
 
         _commandDispatcherMock.Verify(
-            expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(new CreatePreferenceCommand(
-                MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
-                    It.IsAny<Guid>()),
-                    new CreatePreferenceRequest(_userId)), It.IsAny<CancellationToken>()), times: Times.Once);
+            expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
+                new CreatePreferenceCommand(
+                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                        It.IsAny<Guid>()), new CreatePreferenceRequest(_userId)), It.IsAny<CancellationToken>()),
+            times: Times.Once);
     }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
@@ -12,9 +12,9 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
     {
         // Arrange
         _queryDispatcherMock
-            .Setup(expression: x =>
-                x.QueryAsync(new GetPreferencesQuery(
-                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+            .Setup(expression: x => x.QueryAsync(new GetPreferencesQuery(
+                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                        It.IsAny<Guid>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferencesExternalResponse);
@@ -30,9 +30,9 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         preference.Should().BeEquivalentTo(expectation: _getPreferencesExternalResponse);
 
         _queryDispatcherMock.Verify(
-            expression: x =>
-                x.QueryAsync(new GetPreferencesQuery(
-                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+            expression: x => x.QueryAsync(new GetPreferencesQuery(
+                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                        It.IsAny<Guid>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }
@@ -42,9 +42,9 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
     {
         // Arrange
         _queryDispatcherMock
-            .Setup(expression: x =>
-                x.QueryAsync(new GetPreferencesQuery(
-                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+            .Setup(expression: x => x.QueryAsync(new GetPreferencesQuery(
+                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                        It.IsAny<Guid>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: null);
@@ -59,9 +59,9 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         preference.Should().BeNull();
 
         _queryDispatcherMock.Verify(
-            expression: x =>
-                x.QueryAsync(new GetPreferencesQuery(
-                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
+            expression: x => x.QueryAsync(new GetPreferencesQuery(
+                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                        It.IsAny<Guid>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
@@ -29,10 +29,9 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         preference.Should().NotBeNull();
         preference.Should().BeEquivalentTo(expectation: _getPreferencesExternalResponse);
 
-        _queryDispatcherMock.Verify(
-            expression: x => x.QueryAsync(new GetPreferencesQuery(
-                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
-                        It.IsAny<Guid>()),
+        _queryDispatcherMock.Verify(expression: x => x.QueryAsync(new GetPreferencesQuery(
+                MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                    It.IsAny<Guid>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }
@@ -58,10 +57,9 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         // Assert
         preference.Should().BeNull();
 
-        _queryDispatcherMock.Verify(
-            expression: x => x.QueryAsync(new GetPreferencesQuery(
-                    MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
-                        It.IsAny<Guid>()),
+        _queryDispatcherMock.Verify(expression: x => x.QueryAsync(new GetPreferencesQuery(
+                MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
+                    It.IsAny<Guid>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
@@ -13,8 +13,8 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         // Arrange
         _queryDispatcherMock
             .Setup(expression: x =>
-                x.QueryAsync(
-                    new GetPreferencesQuery(MessageContextFactoryMock.Object.Current(null),
+                x.QueryAsync(new GetPreferencesQuery(
+                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferencesExternalResponse);
@@ -31,8 +31,8 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
 
         _queryDispatcherMock.Verify(
             expression: x =>
-                x.QueryAsync(
-                    new GetPreferencesQuery(MessageContextFactoryMock.Object.Current(null),
+                x.QueryAsync(new GetPreferencesQuery(
+                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }
@@ -43,8 +43,8 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         // Arrange
         _queryDispatcherMock
             .Setup(expression: x =>
-                x.QueryAsync(
-                    new GetPreferencesQuery(MessageContextFactoryMock.Object.Current(null),
+                x.QueryAsync(new GetPreferencesQuery(
+                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: null);
@@ -60,8 +60,8 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
 
         _queryDispatcherMock.Verify(
             expression: x =>
-                x.QueryAsync(
-                    new GetPreferencesQuery(MessageContextFactoryMock.Object.Current(null),
+                x.QueryAsync(new GetPreferencesQuery(
+                        MessageContextFactoryMock.Object.Current(It.IsAny<Guid?>(), It.IsAny<string?>()),
                         new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequest_PreferenceTypes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/UserPreferencesProxyTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/UserPreferencesProxyTestBase.cs
@@ -1,5 +1,6 @@
 using Expenso.Shared.Commands.Dispatchers;
 using Expenso.Shared.Queries.Dispatchers;
+using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.UserPreferences.Shared;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Response;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Response;
@@ -17,6 +18,9 @@ internal abstract class UserPreferencesProxyTestBase : TestBase<IUserPreferences
         _queryDispatcherMock = new Mock<IQueryDispatcher>();
         _commandDispatcherMock = new Mock<ICommandDispatcher>();
 
+        _currentMessageContext =
+            MessageContextFactoryMock.Object.Current(messageId: It.IsAny<Guid?>(), moduleId: It.IsAny<string?>());
+
         _getPreferencesExternalResponse = new GetPreferencesResponse(Id: _id, UserId: _userId,
             FinancePreference: new GetPreferencesResponse_FinancePreference(AllowAddFinancePlanSubOwners: false,
                 MaxNumberOfSubFinancePlanSubOwners: 0, AllowAddFinancePlanReviewers: false,
@@ -32,6 +36,7 @@ internal abstract class UserPreferencesProxyTestBase : TestBase<IUserPreferences
             messageContextFactory: MessageContextFactoryMock.Object);
     }
 
+    protected IMessageContext _currentMessageContext = null!;
     protected Mock<ICommandDispatcher> _commandDispatcherMock = null!;
     protected CreatePreferenceResponse _createPreferenceResponse = null!;
     protected GetPreferencesResponse _getPreferencesExternalResponse = null!;

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/PreferenceRepositoryTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/PreferenceRepositoryTestBase.cs
@@ -78,16 +78,16 @@ internal abstract class PreferenceRepositoryTestBase : TestBase<IPreferencesRepo
 
     protected static IList<Guid> _preferenceIds =
     [
-        new Guid(g: "19967114-32ef-4202-90c8-3aa590d14a03"),
-        new Guid(g: "87ddf365-e001-4949-abae-451d7ccd46c1"),
-        new Guid(g: "d3b1e36e-f188-4858-8d07-1b8bcd1b87fb")
+        new(g: "19967114-32ef-4202-90c8-3aa590d14a03"),
+        new(g: "87ddf365-e001-4949-abae-451d7ccd46c1"),
+        new(g: "d3b1e36e-f188-4858-8d07-1b8bcd1b87fb")
     ];
 
     protected static IList<Guid> _userIds =
     [
-        new Guid(g: "527336da-3371-45a9-9b9f-bbd42d01ffc2"),
-        new Guid(g: "3318e89e-fe27-453b-b9cb-3edce39ee187"),
-        new Guid(g: "41e0197a-014f-419a-9521-d0946e88818d")
+        new(g: "527336da-3371-45a9-9b9f-bbd42d01ffc2"),
+        new(g: "3318e89e-fe27-453b-b9cb-3edce39ee187"),
+        new(g: "41e0197a-014f-419a-9521-d0946e88818d")
     ];
 
     private Mock<IUserPreferencesDbContext> _dbContextMock = null!;


### PR DESCRIPTION
Commit overview:
- Added FromParent method in IMessageContextFactory.cs
- Used FromParent optionally in proxies
- Reflected changes in tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Enhanced method signatures across multiple services to include an optional `IMessageContext` parameter, improving context handling for various operations.
	- Added project references to `Expenso.Shared.System.Modules.Constants` and `Expenso.Shared.System.Types` across several projects for better modular integration.
	- Introduced a new test class for `GetUsersAsync` to validate user retrieval functionality.

- **Bug Fixes**
	- Adjusted unit tests to accommodate new method signatures, ensuring they correctly handle the updated parameters.
	- Improved SQL script formatting for better readability.

These changes collectively enhance the flexibility and functionality of the application while maintaining backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->