### PR TITLE
Add indexes into budget sharing module database

### DIFF
--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Configurations/BudgetPermissionEntityTypeConfiguration.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Configurations/BudgetPermissionEntityTypeConfiguration.cs
@@ -22,6 +22,8 @@ internal sealed class BudgetPermissionEntityTypeConfiguration : IEntityTypeConfi
             .IsRequired();
 
         builder.HasIndex(indexExpression: x => x.BudgetId).IsUnique();
+        builder.HasIndex(indexExpression: x => x.OwnerId);
+        builder.HasIndex(indexExpression: x => x.BudgetCode);
 
         builder
             .HasIndex(indexExpression: x => new
@@ -41,6 +43,7 @@ internal sealed class BudgetPermissionEntityTypeConfiguration : IEntityTypeConfi
             .Property(propertyExpression: x => x.BudgetCode)
             .HasConversion(convertToProviderExpression: x => x.Value,
                 convertFromProviderExpression: x => BudgetCode.New(x))
+            .HasMaxLength(maxLength: 18)
             .IsRequired();
 
         builder

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Configurations/BudgetPermissionRequestEntityTypeConfiguration.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Configurations/BudgetPermissionRequestEntityTypeConfiguration.cs
@@ -14,6 +14,9 @@ internal sealed class BudgetPermissionRequestEntityTypeConfiguration : IEntityTy
     {
         builder.ToTable(name: "BudgetPermissionRequests");
         builder.HasKey(keyExpression: x => x.Id);
+        builder.HasIndex(indexExpression: x => x.BudgetId);
+        builder.HasIndex(indexExpression: x => x.BudgetCode);
+        builder.HasIndex(indexExpression: x => x.ParticipantId);
 
         builder
             .Property(propertyExpression: x => x.Id)
@@ -31,6 +34,18 @@ internal sealed class BudgetPermissionRequestEntityTypeConfiguration : IEntityTy
             .Property(propertyExpression: x => x.BudgetCode)
             .HasConversion(convertToProviderExpression: x => x.Value,
                 convertFromProviderExpression: x => BudgetCode.New(x))
+            .IsRequired();
+
+        builder
+            .Property(propertyExpression: x => x.ParticipantId)
+            .HasConversion(convertToProviderExpression: x => x.Value,
+                convertFromProviderExpression: x => PersonId.New(x))
+            .IsRequired();
+
+        builder
+            .Property(propertyExpression: x => x.PermissionType)
+            .HasConversion(convertToProviderExpression: x => x.Value,
+                convertFromProviderExpression: x => PermissionType.Create(x))
             .IsRequired();
 
         builder.OwnsOne<BudgetPermissionRequestStatusTracker>(navigationExpression: x => x.StatusTracker,
@@ -73,17 +88,5 @@ internal sealed class BudgetPermissionRequestEntityTypeConfiguration : IEntityTy
                     .HasColumnName(name: "status")
                     .IsRequired();
             });
-
-        builder
-            .Property(propertyExpression: x => x.ParticipantId)
-            .HasConversion(convertToProviderExpression: x => x.Value,
-                convertFromProviderExpression: x => PersonId.New(x))
-            .IsRequired();
-
-        builder
-            .Property(propertyExpression: x => x.PermissionType)
-            .HasConversion(convertToProviderExpression: x => x.Value,
-                convertFromProviderExpression: x => PermissionType.Create(x))
-            .IsRequired();
     }
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20241123044312_AddIndexes.Designer.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20241123044312_AddIndexes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Expenso.BudgetSharing.Infrastructure.Persistence.EfCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Expenso.BudgetSharing.Infrastructure.Persistence.EfCore.Migrations;
 
 [DbContext(typeof(BudgetSharingDbContext))]
-partial class BudgetSharingDbContextModelSnapshot : ModelSnapshot
+[Migration("20241123044312_AddIndexes")]
+partial class AddIndexes
 {
-    protected override void BuildModel(ModelBuilder modelBuilder)
+    /// <inheritdoc />
+    protected override void BuildTargetModel(ModelBuilder modelBuilder)
     {
 #pragma warning disable 612, 618
         modelBuilder

--- a/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20241123044312_AddIndexes.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Infrastructure/Persistence/EfCore/Migrations/20241123044312_AddIndexes.cs
@@ -1,0 +1,92 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Expenso.BudgetSharing.Infrastructure.Persistence.EfCore.Migrations;
+
+/// <inheritdoc />
+public partial class AddIndexes : Migration
+{
+    /// <inheritdoc />
+    protected override void Up(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.AlterColumn<string>(
+            name: "BudgetCode",
+            schema: "BudgetSharing",
+            table: "BudgetPermissions",
+            type: "character varying(18)",
+            maxLength: 18,
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "text");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_BudgetPermissions_BudgetCode",
+            schema: "BudgetSharing",
+            table: "BudgetPermissions",
+            column: "BudgetCode");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_BudgetPermissions_OwnerId",
+            schema: "BudgetSharing",
+            table: "BudgetPermissions",
+            column: "OwnerId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_BudgetPermissionRequests_BudgetCode",
+            schema: "BudgetSharing",
+            table: "BudgetPermissionRequests",
+            column: "BudgetCode");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_BudgetPermissionRequests_BudgetId",
+            schema: "BudgetSharing",
+            table: "BudgetPermissionRequests",
+            column: "BudgetId");
+
+        migrationBuilder.CreateIndex(
+            name: "IX_BudgetPermissionRequests_ParticipantId",
+            schema: "BudgetSharing",
+            table: "BudgetPermissionRequests",
+            column: "ParticipantId");
+    }
+
+    /// <inheritdoc />
+    protected override void Down(MigrationBuilder migrationBuilder)
+    {
+        migrationBuilder.DropIndex(
+            name: "IX_BudgetPermissions_BudgetCode",
+            schema: "BudgetSharing",
+            table: "BudgetPermissions");
+
+        migrationBuilder.DropIndex(
+            name: "IX_BudgetPermissions_OwnerId",
+            schema: "BudgetSharing",
+            table: "BudgetPermissions");
+
+        migrationBuilder.DropIndex(
+            name: "IX_BudgetPermissionRequests_BudgetCode",
+            schema: "BudgetSharing",
+            table: "BudgetPermissionRequests");
+
+        migrationBuilder.DropIndex(
+            name: "IX_BudgetPermissionRequests_BudgetId",
+            schema: "BudgetSharing",
+            table: "BudgetPermissionRequests");
+
+        migrationBuilder.DropIndex(
+            name: "IX_BudgetPermissionRequests_ParticipantId",
+            schema: "BudgetSharing",
+            table: "BudgetPermissionRequests");
+
+        migrationBuilder.AlterColumn<string>(
+            name: "BudgetCode",
+            schema: "BudgetSharing",
+            table: "BudgetPermissions",
+            type: "text",
+            nullable: false,
+            oldClrType: typeof(string),
+            oldType: "character varying(18)",
+            oldMaxLength: 18);
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced database schema for `BudgetPermission` and `BudgetPermissionRequest` entities, improving query performance with new indexes.
  - Enforced a maximum length constraint of 18 characters on the `BudgetCode` property.

- **Bug Fixes**
  - Ensured required properties are properly configured for `ParticipantId` and `PermissionType`.

- **Documentation**
  - Updated migration documentation to reflect recent changes in indexing and property configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->