### PR TITLE
Add missing budget codes in budget sharing requests

### DIFF
--- a/src/BudgetSharing/Expenso.BudgetSharing.Api/BudgetSharingModule.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Api/BudgetSharingModule.cs
@@ -111,7 +111,7 @@ public sealed class BudgetSharingModule : IModuleDefinition
                     IReadOnlyCollection<GetBudgetPermissionRequestsResponse>> handler,
                 [FromServices] IMessageContextFactory messageContextFactory, [FromQuery] Guid? budgetId = null,
                 [FromQuery] Guid? participantId = null, [FromQuery] Guid? ownerId = null,
-                [FromQuery] bool? forCurrentUser = null,
+                [FromQuery] bool? forCurrentUser = null, [FromQuery] string? budgetCode = null,
                 [FromQuery] GetBudgetPermissionRequestsRequestStatus status =
                     GetBudgetPermissionRequestsRequestStatus.All,
                 [FromQuery] GetBudgetPermissionRequestsRequestPermissionType permissionType =
@@ -120,7 +120,7 @@ public sealed class BudgetSharingModule : IModuleDefinition
             {
                 IReadOnlyCollection<GetBudgetPermissionRequestsResponse>? getPreferences = await handler.HandleAsync(
                     query: new GetBudgetPermissionRequestsQuery(MessageContext: messageContextFactory.Current(),
-                        Payload: new GetBudgetPermissionRequestsRequest(BudgetId: budgetId,
+                        Payload: new GetBudgetPermissionRequestsRequest(BudgetId: budgetId, BudgetCode: budgetCode,
                             ParticipantId: participantId, OwnerId: ownerId, ForCurrentUser: forCurrentUser,
                             Status: status, PermissionType: permissionType)), cancellationToken: cancellationToken);
 
@@ -220,14 +220,14 @@ public sealed class BudgetSharingModule : IModuleDefinition
                 IQueryHandler<GetBudgetPermissionsQuery, IReadOnlyCollection<GetBudgetPermissionsResponse>> handler,
                 [FromServices] IMessageContextFactory messageContextFactory, [FromQuery] Guid? budgetId = null,
                 [FromQuery] Guid? ownerId = null, [FromQuery] Guid? participantId = null,
-                [FromQuery] bool? forCurrentUser = null,
+                [FromQuery] string? budgetCode = null, [FromQuery] bool? forCurrentUser = null,
                 [FromQuery] GetBudgetPermissionsRequestPermissionType permissionType =
                     GetBudgetPermissionsRequestPermissionType.All, CancellationToken cancellationToken = default) =>
             {
                 IReadOnlyCollection<GetBudgetPermissionsResponse>? getPreferences = await handler.HandleAsync(
                     query: new GetBudgetPermissionsQuery(MessageContext: messageContextFactory.Current(),
                         Payload: new GetBudgetPermissionsRequest(BudgetId: budgetId, OwnerId: ownerId,
-                            ParticipantId: participantId, PermissionType: permissionType,
+                            BudgetCode: budgetCode, ParticipantId: participantId, PermissionType: permissionType,
                             ForCurrentUser: forCurrentUser)), cancellationToken: cancellationToken);
 
                 return Results.Ok(value: getPreferences);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Maps/GetBudgetPermissionRequestResponseMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Maps/GetBudgetPermissionRequestResponseMap.cs
@@ -12,6 +12,7 @@ internal static class GetBudgetPermissionRequestResponseMap
         return new GetBudgetPermissionRequestResponse(Id: budgetPermissionRequest.Id.Value,
             BudgetId: budgetPermissionRequest.BudgetId.Value,
             ParticipantId: budgetPermissionRequest.ParticipantId.Value,
+            BudgetCode: budgetPermissionRequest.BudgetCode.Value,
             PermissionType: MapTo(permissionType: budgetPermissionRequest.PermissionType),
             Status: MapTo(budgetPermissionRequestStatus: budgetPermissionRequest.StatusTracker.Status),
             ExpirationDate: budgetPermissionRequest.StatusTracker.ExpirationDate.Value,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequest/DTO/Response/GetBudgetPermissionRequestResponse.cs
@@ -4,6 +4,7 @@ public sealed record GetBudgetPermissionRequestResponse(
     Guid Id,
     Guid BudgetId,
     Guid ParticipantId,
+    string BudgetCode,
     GetBudgetPermissionRequestResponsePermissionType PermissionType,
     GetBudgetPermissionRequestResponseStatus Status,
     DateTimeOffset ExpirationDate,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Maps/GetBudgetPermissionRequestsResponseMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Maps/GetBudgetPermissionRequestsResponseMap.cs
@@ -18,6 +18,7 @@ internal static class GetBudgetPermissionRequestsResponseMap
         return new GetBudgetPermissionRequestsResponse(Id: budgetPermissionRequest.Id.Value,
             BudgetId: budgetPermissionRequest.BudgetId.Value,
             ParticipantId: budgetPermissionRequest.ParticipantId.Value,
+            BudgetCode: budgetPermissionRequest.BudgetCode.Value,
             PermissionType: MapTo(permissionType: budgetPermissionRequest.PermissionType),
             Status: MapTo(budgetPermissionRequestStatus: budgetPermissionRequest.StatusTracker.Status),
             ExpirationDate: budgetPermissionRequest.StatusTracker.ExpirationDate.Value,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Read/GetBudgetPermissionRequests/DTO/Response/GetBudgetPermissionRequestsResponse.cs
@@ -4,6 +4,7 @@ public sealed record GetBudgetPermissionRequestsResponse(
     Guid Id,
     Guid BudgetId,
     Guid ParticipantId,
+    string BudgetCode,
     GetBudgetPermissionRequestsResponsePermissionType PermissionType,
     GetBudgetPermissionRequestsResponseStatus Status,
     DateTimeOffset ExpirationDate,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Maps/GetBudgetPermissionResponseMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Maps/GetBudgetPermissionResponseMap.cs
@@ -9,7 +9,7 @@ internal static class GetBudgetPermissionResponseMap
     public static GetBudgetPermissionResponse MapTo(BudgetPermission budgetPermission)
     {
         return new GetBudgetPermissionResponse(Id: budgetPermission.Id.Value, BudgetId: budgetPermission.BudgetId.Value,
-            OwnerId: budgetPermission.OwnerId.Value,
+            OwnerId: budgetPermission.OwnerId.Value, BudgetCode: budgetPermission.BudgetCode.Value,
             Permissions: budgetPermission.Permissions.Select(selector: MapTo).ToList());
     }
 

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Response/GetBudgetPermissionResponse.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermission/DTO/Response/GetBudgetPermissionResponse.cs
@@ -4,4 +4,5 @@ public record GetBudgetPermissionResponse(
     Guid Id,
     Guid BudgetId,
     Guid OwnerId,
+    string BudgetCode,
     ICollection<GetBudgetPermissionResponsePermission> Permissions);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/DTO/Maps/GetBudgetPermissionsResponseMap.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Read/GetBudgetPermissions/DTO/Maps/GetBudgetPermissionsResponseMap.cs
@@ -16,6 +16,7 @@ internal static class GetBudgetPermissionsResponseMap
     {
         return new GetBudgetPermissionsResponse(Id: budgetPermission.Id.Value,
             BudgetId: budgetPermission.BudgetId.Value, OwnerId: budgetPermission.OwnerId.Value,
+            BudgetCode: budgetPermission.BudgetCode.Value,
             Permissions: budgetPermission.Permissions.Select(selector: MapTo).ToList());
     }
 

--- a/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Response/GetBudgetPermissionsResponse.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Shared/DTO/API/BudgetPermissions/GetBudgetPermissions/Response/GetBudgetPermissionsResponse.cs
@@ -4,4 +4,5 @@ public sealed record GetBudgetPermissionsResponse(
     Guid Id,
     Guid BudgetId,
     Guid OwnerId,
+    string BudgetCode,
     ICollection<GetBudgetPermissionsResponsePermission> Permissions);

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/GetBudgetPermissionsAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Application/Proxy/BudgetSharingProxy/GetBudgetPermissionsAsync.cs
@@ -19,7 +19,7 @@ internal sealed class GetBudgetPermissionsAsync : BudgetSharingProxyTestBase
 
         List<GetBudgetPermissionsResponse> response =
         [
-            new(Id: Guid.NewGuid(), BudgetId: Guid.NewGuid(), OwnerId: Guid.NewGuid(),
+            new(Id: Guid.NewGuid(), BudgetId: Guid.NewGuid(), OwnerId: Guid.NewGuid(), BudgetCode: "BDGT/997/12/2024",
                 Permissions: new List<GetBudgetPermissionsResponsePermission>
                 {
                     new(ParticipantId: Guid.NewGuid(),

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/Jobs/Shared/BackgroundJobs/JobsExecutions/JobExecution.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/Jobs/Shared/BackgroundJobs/JobsExecutions/JobExecution.cs
@@ -46,7 +46,7 @@ internal sealed class JobExecution : IJobExecution
     {
         try
         {
-            DateTime jobExecutionStartTime = _clock.UtcNow.DateTime;
+            DateTimeOffset jobExecutionStartTime = _clock.UtcNow;
 
             JobInstance? jobInstance =
                 await _jobInstanceRepository.GetAsync(id: jobInstanceId, cancellationToken: stoppingToken);
@@ -129,7 +129,7 @@ internal sealed class JobExecution : IJobExecution
                         CrontabSchedule? schedule =
                             CrontabSchedule.Parse(expression: jobEntry.CronExpression, options: options);
 
-                        occurence = schedule?.GetNextOccurrence(baseTime: jobExecutionStartTime);
+                        occurence = schedule?.GetNextOccurrence(baseTime: jobExecutionStartTime.DateTime);
 
                         if (occurence is null)
                         {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added `budgetCode` parameter to budget permission request and permissions endpoints, enhancing filtering capabilities.
	- Introduced `BudgetCode` property in response objects for budget permission requests and permissions, providing additional context.

- **Bug Fixes**
	- Improved handling of query parameters to ensure correct processing of budget codes.

- **Tests**
	- Updated unit tests to include `BudgetCode` in response object creation, ensuring comprehensive coverage of new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->