### PR TITLE
Change PreferenceType enums to PreferenceIncludes

### DIFF
--- a/src/Api/Expenso.Api/REST/Apis/UserPreferences/UserPreferences.Api.http
+++ b/src/Api/Expenso.Api/REST/Apis/UserPreferences/UserPreferences.Api.http
@@ -1,17 +1,17 @@
 ### GetPreference
-GET {{apiHostAddress}}/{{userPreferencesRoute}}/preferences/0d002552-918f-4a1f-b114-7b4138147148?
-    preferenceType=Finance,Notification,General
+GET {{apiHostAddress}}/{{userPreferencesRoute}}/preferences/f5f4e46d-4ec0-4abb-a631-3aa9603a4448?
+    includes=Finance,Notification,General
 Content-Type: application/json
 Authorization: Bearer {{apiAccessToken}}
 
 ### GetCurrentUserPreference
-GET {{apiHostAddress}}/{{userPreferencesRoute}}/preferences/current-user?preferenceType=Finance,Notification,General
+GET {{apiHostAddress}}/{{userPreferencesRoute}}/preferences/current-user?includes=Finance,Notification,General
 Content-Type: application/json
 Authorization: Bearer {{apiAccessToken}}
 
 ### GetPreferences
-GET {{apiHostAddress}}/{{userPreferencesRoute}}/preferences?PreferenceId=0d002552-918f-4a1f-b114-7b4138147148&
-    preferenceType=Finance,Notification,General
+GET {{apiHostAddress}}/{{userPreferencesRoute}}/preferences?PreferenceId=f5f4e46d-4ec0-4abb-a631-3aa9603a4448&
+    includes=Finance,Notification,General
 Content-Type: application/json
 Authorization: Bearer {{apiAccessToken}}
 
@@ -25,7 +25,7 @@ Authorization: Bearer {{apiAccessToken}}
 }
 
 ### UpdatePreference
-PUT {{apiHostAddress}}/{{userPreferencesRoute}}/preferences/0d002552-918f-4a1f-b114-7b4138147148
+PUT {{apiHostAddress}}/{{userPreferencesRoute}}/preferences/f5f4e46d-4ec0-4abb-a631-3aa9603a4448
 Content-Type: application/json
 Authorization: Bearer {{apiAccessToken}}
 

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/ConfirmParticipantionDomainService.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/ConfirmParticipantionDomainService.cs
@@ -64,7 +64,7 @@ internal sealed class ConfirmParticipantionDomainService : IConfirmParticipantio
 
         GetPreferencesResponse? preference = await _userPreferencesProxy.GetPreferences(
             getPreferenceRequest: new GetPreferencesRequest(UserId: budgetPermission.OwnerId.Value,
-                PreferenceType: GetPreferencesRequestPreferenceTypes.Finance), cancellationToken: cancellationToken);
+                Includes: GetPreferencesRequestPreferenceIncludes.Finance), cancellationToken: cancellationToken);
 
         if (preference?.FinancePreference is null)
         {

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationAsync.cs
@@ -33,7 +33,7 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             .Setup(expression: x =>
                 x.GetPreferences(
                     new GetPreferencesRequest(null, _budgetPermission.OwnerId.Value,
-                        GetPreferencesRequestPreferenceTypes.Finance), It.IsAny<IMessageContext>(),
+                        GetPreferencesRequestPreferenceIncludes.Finance), It.IsAny<IMessageContext>(),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferenceResponse);
 
@@ -131,7 +131,7 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             .Setup(expression: x =>
                 x.GetPreferences(
                     new GetPreferencesRequest(null, _budgetPermission.OwnerId.Value,
-                        GetPreferencesRequestPreferenceTypes.Finance), It.IsAny<IMessageContext>(),
+                        GetPreferencesRequestPreferenceIncludes.Finance), It.IsAny<IMessageContext>(),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: null);
 
@@ -165,7 +165,7 @@ internal sealed class ConfirmParticipationAsync : ConfirmParticipationDomainServ
             .Setup(expression: x =>
                 x.GetPreferences(
                     new GetPreferencesRequest(null, _budgetPermission.OwnerId.Value,
-                        GetPreferencesRequestPreferenceTypes.Finance), It.IsAny<IMessageContext>(),
+                        GetPreferencesRequestPreferenceIncludes.Finance), It.IsAny<IMessageContext>(),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferenceResponse with
             {

--- a/src/UserPreferences/Expenso.UserPreferences.Api/UserPreferencesModule.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Api/UserPreferencesModule.cs
@@ -33,7 +33,7 @@ namespace Expenso.UserPreferences.Api;
 
 public sealed class UserPreferencesModule : IModuleDefinition
 {
-    public string ModuleName => Names.UserPreferencesModule;
+    public string ModuleName => ModuleNames.UserPreferencesModule;
 
     public string ModulePrefix => "/user-preferences";
 
@@ -59,12 +59,12 @@ public sealed class UserPreferencesModule : IModuleDefinition
             AccessControl: AccessControl.User, HttpVerb: HttpVerb.Get, Handler: async (
                 [FromServices] IQueryHandler<GetPreferenceQuery, GetPreferenceResponse> handler,
                 [FromServices] IMessageContextFactory messageContextFactory, [FromRoute] Guid id,
-                [FromQuery] GetPreferenceRequestPreferenceTypes preferenceType =
-                    GetPreferenceRequestPreferenceTypes.None, CancellationToken cancellationToken = default) =>
+                [FromQuery] GetPreferenceRequestPreferenceIncludes includes =
+                    GetPreferenceRequestPreferenceIncludes.None, CancellationToken cancellationToken = default) =>
             {
                 GetPreferenceResponse? response = await handler.HandleAsync(
                     query: new GetPreferenceQuery(MessageContext: messageContextFactory.Current(),
-                        Payload: new GetPreferenceRequest(PreferenceId: id, PreferenceType: preferenceType)),
+                        Payload: new GetPreferenceRequest(PreferenceId: id, Includes: includes)),
                     cancellationToken: cancellationToken);
 
                 return Results.Ok(value: response);
@@ -76,13 +76,13 @@ public sealed class UserPreferencesModule : IModuleDefinition
                 [FromServices]
                 IQueryHandler<GetPreferenceForCurrentUserQuery, GetPreferenceForCurrentUserResponse> handler,
                 [FromServices] IMessageContextFactory messageContextFactory,
-                [FromQuery] GetPreferenceForCurrentUserRequestPreferenceTypes preferenceType =
-                    GetPreferenceForCurrentUserRequestPreferenceTypes.None,
+                [FromQuery] GetPreferenceForCurrentUserRequestPreferenceIncludes includes =
+                    GetPreferenceForCurrentUserRequestPreferenceIncludes.None,
                 CancellationToken cancellationToken = default) =>
             {
                 GetPreferenceForCurrentUserResponse? response = await handler.HandleAsync(
                     query: new GetPreferenceForCurrentUserQuery(MessageContext: messageContextFactory.Current(),
-                        Payload: new GetPreferenceForCurrentUserRequest(PreferenceType: preferenceType)),
+                        Payload: new GetPreferenceForCurrentUserRequest(Includes: includes)),
                     cancellationToken: cancellationToken);
 
                 return Results.Ok(value: response);
@@ -93,13 +93,13 @@ public sealed class UserPreferencesModule : IModuleDefinition
                 [FromServices] IQueryHandler<GetPreferencesQuery, GetPreferencesResponse> handler,
                 [FromServices] IMessageContextFactory messageContextFactory, [FromQuery] Guid? id = null,
                 [FromQuery] Guid? userId = null,
-                [FromQuery] GetPreferencesRequestPreferenceTypes preferenceType =
-                    GetPreferencesRequestPreferenceTypes.None, CancellationToken cancellationToken = default) =>
+                [FromQuery] GetPreferencesRequestPreferenceIncludes includes =
+                    GetPreferencesRequestPreferenceIncludes.None, CancellationToken cancellationToken = default) =>
             {
                 GetPreferencesResponse? response = await handler.HandleAsync(
                     query: new GetPreferencesQuery(MessageContext: messageContextFactory.Current(),
-                        Payload: new GetPreferencesRequest(PreferenceId: id, UserId: userId,
-                            PreferenceType: preferenceType)), cancellationToken: cancellationToken);
+                        Payload: new GetPreferencesRequest(PreferenceId: id, UserId: userId, Includes: includes)),
+                    cancellationToken: cancellationToken);
 
                 return Results.Ok(value: response);
             });

--- a/src/UserPreferences/Expenso.UserPreferences.Api/UserPreferencesModule.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Api/UserPreferencesModule.cs
@@ -33,7 +33,7 @@ namespace Expenso.UserPreferences.Api;
 
 public sealed class UserPreferencesModule : IModuleDefinition
 {
-    public string ModuleName => ModuleNames.UserPreferencesModule;
+    public string ModuleName => Names.UserPreferencesModule;
 
     public string ModulePrefix => "/user-preferences";
 

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequest.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequest.cs
@@ -2,4 +2,4 @@
 
 public sealed record GetPreferenceRequest(
     Guid? PreferenceId = null,
-    GetPreferenceRequestPreferenceTypes? PreferenceType = null);
+    GetPreferenceRequestPreferenceIncludes? Includes = null);

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequestPreferenceIncludes.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/DTO/Request/GetPreferenceRequestPreferenceIncludes.cs
@@ -1,7 +1,7 @@
 ﻿namespace Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreference.DTO.Request;
 
 [Flags]
-public enum GetPreferenceRequestPreferenceTypes
+public enum GetPreferenceRequestPreferenceIncludes
 {
     None = 0,
     Finance = 1,

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/GetPreferenceQueryHandler.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreference/GetPreferenceQueryHandler.cs
@@ -7,7 +7,7 @@ using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPrefe
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreference.DTO.Response;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 using Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreference;
 
@@ -26,13 +26,11 @@ internal sealed class GetPreferenceQueryHandler : IQueryHandler<GetPreferenceQue
         PreferenceQuerySpecification querySpecification = new()
         {
             PreferenceId = query.Payload?.PreferenceId,
-            PreferenceType = query.Payload?.PreferenceType
-                .SafeCast<PreferenceTypes, GetPreferenceRequestPreferenceTypes>(),
+            Includes = query.Payload?.Includes.SafeCast<PreferenceIncludes, GetPreferenceRequestPreferenceIncludes>(),
             UseTracking = false
         };
 
-        Preference preference =
-            await _preferencesRepository.GetAsync(preferenceQuerySpecification: querySpecification,
+        Preference preference = await _preferencesRepository.GetAsync(querySpecification: querySpecification,
                 cancellationToken: cancellationToken) ?? throw new NotFoundException(resourceName: nameof(Preference),
                 identifierType: IdentifierType.Query(), identifier: querySpecification);
 

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/DTO/Request/GetPreferenceForCurrentUserRequest.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/DTO/Request/GetPreferenceForCurrentUserRequest.cs
@@ -1,4 +1,4 @@
 ﻿namespace Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser.DTO.Request;
 
 public sealed record GetPreferenceForCurrentUserRequest(
-    GetPreferenceForCurrentUserRequestPreferenceTypes? PreferenceType = null);
+    GetPreferenceForCurrentUserRequestPreferenceIncludes? Includes = null);

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/DTO/Request/GetPreferenceForCurrentUserRequestPreferenceIncludes.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/DTO/Request/GetPreferenceForCurrentUserRequestPreferenceIncludes.cs
@@ -1,7 +1,7 @@
 ﻿namespace Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser.DTO.Request;
 
 [Flags]
-public enum GetPreferenceForCurrentUserRequestPreferenceTypes
+public enum GetPreferenceForCurrentUserRequestPreferenceIncludes
 {
     None = 0,
     Finance = 1,

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/GetPreferenceForCurrentUserQueryHandler.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/GetPreferenceForCurrentUserQueryHandler.cs
@@ -8,7 +8,7 @@ using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPrefe
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser.DTO.Response;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 using Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser;
 
@@ -43,13 +43,12 @@ internal sealed class
         PreferenceQuerySpecification querySpecification = new()
         {
             UserId = currentUserId,
-            PreferenceType = query.Payload?.PreferenceType
-                .SafeCast<PreferenceTypes, GetPreferenceForCurrentUserRequestPreferenceTypes>(),
+            Includes = query.Payload?.Includes
+                .SafeCast<PreferenceIncludes, GetPreferenceForCurrentUserRequestPreferenceIncludes>(),
             UseTracking = false
         };
 
-        Preference preference =
-            await _preferencesRepository.GetAsync(preferenceQuerySpecification: querySpecification,
+        Preference preference = await _preferencesRepository.GetAsync(querySpecification: querySpecification,
                 cancellationToken: cancellationToken) ?? throw new NotFoundException(resourceName: nameof(Preference),
                 identifierType: IdentifierType.Query(), identifier: querySpecification);
 

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferences/GetPreferencesQueryHandler.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Read/Queries/GetPreferences/GetPreferencesQueryHandler.cs
@@ -5,7 +5,7 @@ using Expenso.Shared.System.Types.TypesExtensions;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferences.DTO.Maps;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 using Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Request;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Response;
 
@@ -28,13 +28,11 @@ internal sealed class GetPreferencesQueryHandler : IQueryHandler<GetPreferencesQ
         {
             PreferenceId = query.Payload?.PreferenceId,
             UserId = query.Payload?.UserId,
-            PreferenceType = query.Payload?.PreferenceType
-                .SafeCast<PreferenceTypes, GetPreferencesRequestPreferenceTypes>(),
+            Includes = query.Payload?.Includes.SafeCast<PreferenceIncludes, GetPreferencesRequestPreferenceIncludes>(),
             UseTracking = false
         };
 
-        Preference preference =
-            await _preferencesRepository.GetAsync(preferenceQuerySpecification: querySpecification,
+        Preference preference = await _preferencesRepository.GetAsync(querySpecification: querySpecification,
                 cancellationToken: cancellationToken) ?? throw new NotFoundException(resourceName: nameof(Preference),
                 identifierType: IdentifierType.Query(), identifier: querySpecification);
 

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/CreatePreferenceCommandHandler.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/CreatePreferenceCommandHandler.cs
@@ -5,7 +5,7 @@ using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.Create
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.CreatePreference.Factories;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 using Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Response;
 
 namespace Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.CreatePreference;
@@ -32,8 +32,7 @@ internal sealed class
             UseTracking = false
         };
 
-        bool dbUserPreferencesExists =
-            await _preferencesRepository.ExistsAsync(preferenceQuerySpecification: querySpecification,
+        bool dbUserPreferencesExists = await _preferencesRepository.ExistsAsync(querySpecification: querySpecification,
                 cancellationToken: cancellationToken);
 
         if (dbUserPreferencesExists)

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/UpdatePreference/UpdatePreferenceCommandHandler.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/UpdatePreference/UpdatePreferenceCommandHandler.cs
@@ -7,7 +7,7 @@ using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.Update
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.UpdatePreference.DTO.Request;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 using Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 using Expenso.UserPreferences.Shared.DTO.MessageBus.UpdatePreference.FinancePreferences;
 using Expenso.UserPreferences.Shared.DTO.MessageBus.UpdatePreference.GeneralPreferences;
 using Expenso.UserPreferences.Shared.DTO.MessageBus.UpdatePreference.NotificationPreferences;
@@ -35,10 +35,10 @@ internal sealed class UpdatePreferenceCommandHandler : ICommandHandler<UpdatePre
     public async Task HandleAsync(UpdatePreferenceCommand command, CancellationToken cancellationToken)
     {
         PreferenceQuerySpecification preferenceQuerySpecification = new(PreferenceId: command.PreferenceId,
-            UseTracking: true, PreferenceType: PreferenceTypes.All);
+            UseTracking: true, Includes: PreferenceIncludes.All);
 
         Preference? dbPreference = await _preferencesRepository.GetAsync(
-            preferenceQuerySpecification: preferenceQuerySpecification, cancellationToken: cancellationToken);
+            querySpecification: preferenceQuerySpecification, cancellationToken: cancellationToken);
 
         if (dbPreference is null)
         {

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
@@ -35,7 +35,7 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
         return await _queryDispatcher.QueryAsync(
             query: new GetPreferencesQuery(
                 MessageContext: _messageContextFactory.FromParent(parent: messageContext,
-                    moduleId: ModuleNames.UserPreferencesModule), Payload: request),
+                    moduleId: Names.UserPreferencesModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 
@@ -45,7 +45,7 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
         return await _commandDispatcher.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
             command: new CreatePreferenceCommand(
                 MessageContext: _messageContextFactory.FromParent(parent: messageContext,
-                    moduleId: ModuleNames.UserPreferencesModule), Payload: request),
+                    moduleId: Names.UserPreferencesModule), Payload: request),
             cancellationToken: cancellationToken);
     }
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Proxy/UserPreferencesProxy.cs
@@ -35,7 +35,8 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
         return await _queryDispatcher.QueryAsync(
             query: new GetPreferencesQuery(
                 MessageContext: _messageContextFactory.FromParent(parent: messageContext,
-                    moduleId: Names.UserPreferencesModule), Payload: request), cancellationToken: cancellationToken);
+                    moduleId: ModuleNames.UserPreferencesModule), Payload: request),
+            cancellationToken: cancellationToken);
     }
 
     public async Task<CreatePreferenceResponse?> CreatePreferencesAsync(CreatePreferenceRequest request,
@@ -44,6 +45,7 @@ internal sealed class UserPreferencesProxy : IUserPreferencesProxy
         return await _commandDispatcher.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
             command: new CreatePreferenceCommand(
                 MessageContext: _messageContextFactory.FromParent(parent: messageContext,
-                    moduleId: Names.UserPreferencesModule), Payload: request), cancellationToken: cancellationToken);
+                    moduleId: ModuleNames.UserPreferencesModule), Payload: request),
+            cancellationToken: cancellationToken);
     }
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/IPreferencesRepository.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/IPreferencesRepository.cs
@@ -1,14 +1,14 @@
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
 
 internal interface IPreferencesRepository
 {
-    Task<Preference?> GetAsync(PreferenceQuerySpecification preferenceQuerySpecification,
+    Task<Preference?> GetAsync(PreferenceQuerySpecification querySpecification,
         CancellationToken cancellationToken);
 
-    Task<bool> ExistsAsync(PreferenceQuerySpecification preferenceQuerySpecification,
+    Task<bool> ExistsAsync(PreferenceQuerySpecification querySpecification,
         CancellationToken cancellationToken);
 
     Task<Preference> CreateAsync(Preference preference, CancellationToken cancellationToken);

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/Specifications/PreferenceIncludes.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/Specifications/PreferenceIncludes.cs
@@ -1,7 +1,7 @@
-﻿namespace Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+﻿namespace Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 [Flags]
-internal enum PreferenceTypes
+internal enum PreferenceIncludes
 {
     None = 0,
     Finance = 1,

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/Specifications/PreferenceQuerySpecification.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Domain/Preferences/Repositories/Specifications/PreferenceQuerySpecification.cs
@@ -3,19 +3,20 @@ using System.Linq.Expressions;
 using Expenso.Shared.System.Expressions.And;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 
-namespace Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+namespace Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 internal sealed record PreferenceQuerySpecification(
     Guid? PreferenceId = null,
     Guid? UserId = null,
     bool? UseTracking = null,
-    PreferenceTypes? PreferenceType = null)
+    PreferenceIncludes? Includes = null)
 {
-    private static readonly Dictionary<PreferenceTypes, Expression<Func<Preference, object>>> PreferenceTypeMap = new()
+    private static readonly Dictionary<PreferenceIncludes, Expression<Func<Preference, object>>> PreferenceIncludesMap =
+        new()
     {
-        { PreferenceTypes.Finance, x => x.FinancePreference! },
-        { PreferenceTypes.Notification, x => x.NotificationPreference! },
-        { PreferenceTypes.General, x => x.GeneralPreference! }
+        { PreferenceIncludes.Finance, x => x.FinancePreference! },
+        { PreferenceIncludes.Notification, x => x.NotificationPreference! },
+        { PreferenceIncludes.General, x => x.GeneralPreference! }
     };
 
     public Expression<Func<Preference, bool>> Filter()
@@ -39,10 +40,10 @@ internal sealed record PreferenceQuerySpecification(
 
     public IEnumerable<Expression<Func<Preference, object>>> Include()
     {
-        PreferenceTypes preferenceTypes = PreferenceType ?? PreferenceTypes.None;
+        PreferenceIncludes includes = Includes ?? PreferenceIncludes.None;
 
-        return PreferenceTypeMap
-            .Where(predicate: kv => preferenceTypes.HasFlag(flag: kv.Key))
+        return PreferenceIncludesMap
+            .Where(predicate: kv => includes.HasFlag(flag: kv.Key))
             .Select(selector: kv => kv.Value)
             .ToArray();
     }

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Persistence/EfCore/Repositories/PreferencesRepository.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Persistence/EfCore/Repositories/PreferencesRepository.cs
@@ -1,7 +1,7 @@
 using Expenso.Shared.Database.EfCore.Queryable;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
 using Expenso.UserPreferences.Core.Domain.Preferences.Repositories;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 using Microsoft.EntityFrameworkCore;
 
@@ -17,23 +17,23 @@ internal sealed class PreferencesRepository : IPreferencesRepository
                                     throw new ArgumentNullException(paramName: nameof(userPreferencesDbContext));
     }
 
-    public async Task<Preference?> GetAsync(PreferenceQuerySpecification preferenceQuerySpecification,
+    public async Task<Preference?> GetAsync(PreferenceQuerySpecification querySpecification,
         CancellationToken cancellationToken)
     {
         return await _userPreferencesDbContext
-            .Preferences.Tracking(useTracking: preferenceQuerySpecification.UseTracking)
-            .IncludeMany(includeExpression: preferenceQuerySpecification.Include())
-            .SingleOrDefaultAsync(predicate: preferenceQuerySpecification.Filter(),
+            .Preferences.Tracking(useTracking: querySpecification.UseTracking)
+            .IncludeMany(includeExpression: querySpecification.Include())
+            .SingleOrDefaultAsync(predicate: querySpecification.Filter(),
                 cancellationToken: cancellationToken);
     }
 
-    public async Task<bool> ExistsAsync(PreferenceQuerySpecification preferenceQuerySpecification,
+    public async Task<bool> ExistsAsync(PreferenceQuerySpecification querySpecification,
         CancellationToken cancellationToken)
     {
         return await _userPreferencesDbContext
-            .Preferences.Tracking(useTracking: preferenceQuerySpecification.UseTracking)
-            .IncludeMany(includeExpression: preferenceQuerySpecification.Include())
-            .AnyAsync(predicate: preferenceQuerySpecification.Filter(), cancellationToken: cancellationToken);
+            .Preferences.Tracking(useTracking: querySpecification.UseTracking)
+            .IncludeMany(includeExpression: querySpecification.Include())
+            .AnyAsync(predicate: querySpecification.Filter(), cancellationToken: cancellationToken);
     }
 
     public async Task<Preference> CreateAsync(Preference preference, CancellationToken cancellationToken)

--- a/src/UserPreferences/Expenso.UserPreferences.Shared/DTO/API/GetPreference/Request/GetPreferencesRequest.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Shared/DTO/API/GetPreference/Request/GetPreferencesRequest.cs
@@ -3,4 +3,4 @@
 public sealed record GetPreferencesRequest(
     Guid? PreferenceId = null,
     Guid? UserId = null,
-    GetPreferencesRequestPreferenceTypes? PreferenceType = null);
+    GetPreferencesRequestPreferenceIncludes? Includes = null);

--- a/src/UserPreferences/Expenso.UserPreferences.Shared/DTO/API/GetPreference/Request/GetPreferencesRequestPreferenceIncludes.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Shared/DTO/API/GetPreference/Request/GetPreferencesRequestPreferenceIncludes.cs
@@ -1,7 +1,7 @@
 ﻿namespace Expenso.UserPreferences.Shared.DTO.API.GetPreference.Request;
 
 [Flags]
-public enum GetPreferencesRequestPreferenceTypes
+public enum GetPreferencesRequestPreferenceIncludes
 {
     None = 0,
     Finance = 1,

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/GetUserPreferences.cs
@@ -15,14 +15,14 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
             .Setup(expression: x => x.QueryAsync(new GetPreferencesQuery(
                     MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
                         It.IsAny<Guid>()),
-                    new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceTypes>())),
+                    new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceIncludes>())),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _getPreferencesExternalResponse);
 
         // Act
         GetPreferencesResponse? preference = await TestCandidate.GetPreferences(
             getPreferenceRequest: new GetPreferencesRequest(PreferenceId: null, UserId: _userId,
-                PreferenceType: It.IsAny<GetPreferencesRequestPreferenceTypes>()),
+                Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()),
             cancellationToken: It.IsAny<CancellationToken>());
 
         // Assert
@@ -32,7 +32,7 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         _queryDispatcherMock.Verify(expression: x => x.QueryAsync(new GetPreferencesQuery(
                 MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
                     It.IsAny<Guid>()),
-                new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceTypes>())),
+                new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceIncludes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }
 
@@ -44,14 +44,14 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
             .Setup(expression: x => x.QueryAsync(new GetPreferencesQuery(
                     MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
                         It.IsAny<Guid>()),
-                    new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceTypes>())),
+                    new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceIncludes>())),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: null);
 
         // Act
         GetPreferencesResponse? preference = await TestCandidate.GetPreferences(
             getPreferenceRequest: new GetPreferencesRequest(PreferenceId: null, UserId: _userId,
-                PreferenceType: It.IsAny<GetPreferencesRequestPreferenceTypes>()),
+                Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()),
             cancellationToken: It.IsAny<CancellationToken>());
 
         // Assert
@@ -60,7 +60,7 @@ internal sealed class GetUserPreferences : UserPreferencesProxyTestBase
         _queryDispatcherMock.Verify(expression: x => x.QueryAsync(new GetPreferencesQuery(
                 MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
                     It.IsAny<Guid>()),
-                new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceTypes>())),
+                new GetPreferencesRequest(null, _userId, It.IsAny<GetPreferencesRequestPreferenceIncludes>())),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreference/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreference/HandleAsync.cs
@@ -2,7 +2,7 @@ using Expenso.Shared.System.Types.Exceptions;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreference;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreference.DTO.Request;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreference.DTO.Response;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Tests.UnitTests.Application.Preferences.Read.Queries.GetPreference;
 
@@ -15,11 +15,11 @@ internal sealed class HandleAsync : GetPreferenceQueryHandlerTestBase
         // Arrange
         GetPreferenceQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferenceRequest(PreferenceId: _id,
-                PreferenceType: It.IsAny<GetPreferenceRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferenceRequestPreferenceIncludes>()));
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceTypes>()),
+                x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _preference);
 
@@ -31,8 +31,8 @@ internal sealed class HandleAsync : GetPreferenceQueryHandlerTestBase
         result.Should().NotBeNull();
         result.Should().BeEquivalentTo(expectation: _getPreferenceResponse);
 
-        _preferenceRepositoryMock.Verify(
-            expression: x => x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceTypes>()),
+        _preferenceRepositoryMock.Verify(expression: x =>
+            x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
                 It.IsAny<CancellationToken>()), times: Times.Once);
     }
 
@@ -42,7 +42,7 @@ internal sealed class HandleAsync : GetPreferenceQueryHandlerTestBase
         // Arrange
         GetPreferenceQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferenceRequest(PreferenceId: _id,
-                PreferenceType: It.IsAny<GetPreferenceRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferenceRequestPreferenceIncludes>()));
 
         // Act
         Func<Task> action = async () =>

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/HandleAsync.cs
@@ -2,7 +2,7 @@ using Expenso.Shared.System.Types.Exceptions;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser.DTO.Request;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser.DTO.Response;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Tests.UnitTests.Application.Preferences.Read.Queries.GetPreferenceForCurrentUser;
 
@@ -15,13 +15,13 @@ internal sealed class HandleAsync : GetPreferenceForCurrentUserQueryHandlerTestB
         // Arrange
         GetPreferenceForCurrentUserQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferenceForCurrentUserRequest(
-                PreferenceType: It.IsAny<GetPreferenceForCurrentUserRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferenceForCurrentUserRequestPreferenceIncludes>()));
 
         _userContextAccessorMock.Setup(expression: x => x.Get()).Returns(value: _executionContextMock.Object);
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceTypes>()),
+                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _preference);
 
@@ -35,7 +35,7 @@ internal sealed class HandleAsync : GetPreferenceForCurrentUserQueryHandlerTestB
 
         _preferenceRepositoryMock.Verify(
             expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceTypes>()),
+                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()), times: Times.Once);
 
         _userContextAccessorMock.Verify(expression: x => x.Get(), times: Times.Once);
@@ -47,7 +47,7 @@ internal sealed class HandleAsync : GetPreferenceForCurrentUserQueryHandlerTestB
         // Arrange
         GetPreferenceForCurrentUserQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferenceForCurrentUserRequest(
-                PreferenceType: It.IsAny<GetPreferenceForCurrentUserRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferenceForCurrentUserRequestPreferenceIncludes>()));
 
         // Act
         Func<Task> action = () =>

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferences/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferences/HandleAsync.cs
@@ -1,6 +1,6 @@
 using Expenso.Shared.System.Types.Exceptions;
 using Expenso.UserPreferences.Core.Application.Preferences.Read.Queries.GetPreferences;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Request;
 using Expenso.UserPreferences.Shared.DTO.API.GetPreference.Response;
 
@@ -15,11 +15,11 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
         // Arrange
         GetPreferencesQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferencesRequest(PreferenceId: _id,
-                PreferenceType: It.IsAny<GetPreferencesRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()));
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceTypes>()),
+                x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _preference);
 
@@ -31,8 +31,8 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
         result.Should().NotBeNull();
         result.Should().BeEquivalentTo(expectation: _getPreferenceResponse);
 
-        _preferenceRepositoryMock.Verify(
-            expression: x => x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceTypes>()),
+        _preferenceRepositoryMock.Verify(expression: x =>
+            x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
                 It.IsAny<CancellationToken>()), times: Times.Once);
     }
 
@@ -42,11 +42,11 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
         // Arrange
         GetPreferencesQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferencesRequest(UserId: _userId,
-                PreferenceType: It.IsAny<GetPreferencesRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()));
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceTypes>()),
+                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _preference);
 
@@ -60,7 +60,7 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
 
         _preferenceRepositoryMock.Verify(
             expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceTypes>()),
+                x.GetAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()), times: Times.Once);
     }
 
@@ -70,7 +70,7 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
         // Arrange
         GetPreferencesQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferencesRequest(PreferenceId: _id,
-                PreferenceType: It.IsAny<GetPreferencesRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()));
 
         // Act
         Func<Task> action = async () =>
@@ -86,7 +86,7 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
         // Arrange
         GetPreferencesQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
             Payload: new GetPreferencesRequest(UserId: _userId,
-                PreferenceType: It.IsAny<GetPreferencesRequestPreferenceTypes>()));
+                Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()));
 
         // Act
         Func<Task> action = async () =>

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/HandleAsync.cs
@@ -2,7 +2,7 @@ using Expenso.Shared.System.Types.Exceptions;
 using Expenso.Shared.System.Types.Exceptions.Models;
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.CreatePreference;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Request;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Response;
 
@@ -21,7 +21,7 @@ internal sealed class HandleAsync : CreatePreferenceCommandHandlerTestBase
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.ExistsAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceTypes>()),
+                x.ExistsAsync(new PreferenceQuerySpecification(null, _userId, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: false);
 

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandHandler/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandHandler/HandleAsync.cs
@@ -3,7 +3,7 @@ using Expenso.Shared.System.Types.Exceptions.Models;
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.UpdatePreference;
 using Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.UpdatePreference.DTO.Request;
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 using Expenso.UserPreferences.Shared.DTO.MessageBus.UpdatePreference.FinancePreferences;
 using Expenso.UserPreferences.Shared.DTO.MessageBus.UpdatePreference.GeneralPreferences;
 using Expenso.UserPreferences.Shared.DTO.MessageBus.UpdatePreference.NotificationPreferences;
@@ -29,7 +29,7 @@ internal sealed class HandleAsync : UpdatePreferenceCommandHandlerTestBase
                 GeneralPreference: new UpdatePreferenceRequestGeneralPreference(UseDarkMode: true)));
 
         PreferenceQuerySpecification preferenceQuerySpecification =
-            new(PreferenceId: _id, UseTracking: true, PreferenceType: PreferenceTypes.All);
+            new(PreferenceId: _id, UseTracking: true, Includes: PreferenceIncludes.All);
 
         _preferenceRepositoryMock
             .Setup(expression: x => x.GetAsync(preferenceQuerySpecification, It.IsAny<CancellationToken>()))
@@ -78,7 +78,7 @@ internal sealed class HandleAsync : UpdatePreferenceCommandHandlerTestBase
                 GeneralPreference: new UpdatePreferenceRequestGeneralPreference(UseDarkMode: true)));
 
         PreferenceQuerySpecification preferenceQuerySpecification =
-            new(PreferenceId: _id, UseTracking: true, PreferenceType: PreferenceTypes.All);
+            new(PreferenceId: _id, UseTracking: true, Includes: PreferenceIncludes.All);
 
         _preferenceRepositoryMock
             .Setup(expression: x => x.GetAsync(preferenceQuerySpecification, It.IsAny<CancellationToken>()))

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/GetByIdAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/GetByIdAsync.cs
@@ -1,5 +1,5 @@
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Tests.UnitTests.Persistence.EfCore.Repositories.PreferencesRepository;
 
@@ -17,7 +17,7 @@ internal sealed class GetByIdAsync : PreferenceRepositoryTestBase
         };
 
         // Act
-        Preference? preference = await TestCandidate.GetAsync(preferenceQuerySpecification: querySpecification,
+        Preference? preference = await TestCandidate.GetAsync(querySpecification: querySpecification,
             cancellationToken: default);
 
         // Assert

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/GetByUserIdAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/GetByUserIdAsync.cs
@@ -1,5 +1,5 @@
 using Expenso.UserPreferences.Core.Domain.Preferences.Model;
-using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Filters;
+using Expenso.UserPreferences.Core.Domain.Preferences.Repositories.Specifications;
 
 namespace Expenso.UserPreferences.Tests.UnitTests.Persistence.EfCore.Repositories.PreferencesRepository;
 
@@ -17,7 +17,7 @@ internal sealed class GetByUserIdAsync : PreferenceRepositoryTestBase
         };
 
         // Act
-        Preference? preference = await TestCandidate.GetAsync(preferenceQuerySpecification: querySpecification,
+        Preference? preference = await TestCandidate.GetAsync(querySpecification: querySpecification,
             cancellationToken: default);
 
         // Assert


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated API endpoints for user preferences to use `includes` instead of `preferenceType`, enhancing flexibility in fetching user preferences.

- **Bug Fixes**
	- Resolved inconsistencies in parameter naming across various methods and classes to improve clarity and maintainability.

- **Documentation**
	- Updated internal documentation to reflect changes in API specifications and request structures.

- **Tests**
	- Modified unit tests to align with updated request parameters and specifications for user preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->