### PR TITLE
Pass optional ids in create requests

### DIFF
--- a/src/Api/Tests/Expenso.Api.Tests.E2E/BudgetSharing/BudgetPermissionRequests/AssignParticipant.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/BudgetSharing/BudgetPermissionRequests/AssignParticipant.cs
@@ -14,11 +14,12 @@ internal sealed class AssignParticipant : BudgetPermissionRequestTestBase
         // Arrange
         _httpClient.SetFakeBearerToken(token: _claims);
         const string requestPath = "budget-sharing/budget-permission-requests";
+        Guid budgetPermissioRequestId = Guid.NewGuid();
 
         // Act
         HttpResponseMessage response = await _httpClient.PostAsJsonAsync(requestUri: requestPath,
-            value: new AssignParticipantRequest(BudgetId: BudgetPermissionDataInitializer.BudgetIds[index: 1],
-                Email: FakeIamProxy.ExistingEmails[2],
+            value: new AssignParticipantRequest(BudgetPermissionRequestId: budgetPermissioRequestId,
+                BudgetId: BudgetPermissionDataInitializer.BudgetIds[index: 1], Email: FakeIamProxy.ExistingEmails[2],
                 PermissionType: AssignParticipantRequestPermissionType.Reviewer));
 
         // Assert
@@ -27,7 +28,7 @@ internal sealed class AssignParticipant : BudgetPermissionRequestTestBase
         AssignParticipantResponse? responseContent =
             await response.Content.ReadFromJsonAsync<AssignParticipantResponse>();
 
-        responseContent?.BudgetPermissionRequestId.Should().NotBeEmpty();
+        responseContent?.BudgetPermissionRequestId.Should().Be(expected: budgetPermissioRequestId);
     }
 
     [Test]

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/TestData/BudgetSharing/BudgetPermissionDataInitializer.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/TestData/BudgetSharing/BudgetPermissionDataInitializer.cs
@@ -27,9 +27,9 @@ internal static class BudgetPermissionDataInitializer
         CancellationToken cancellationToken)
     {
         Guid correlationId = Guid.NewGuid();
-        
+
         IList<(Guid budgetId, string email, AssignParticipantRequestPermissionType permissionType)>
-            budgetPermissionRequestIds =
+            budgetPermissionModels =
             [
                 (new Guid(g: "527336da-3371-45a9-9b9f-bbd42d01ffc2"), FakeIamProxy.ExistingEmails[1],
                     AssignParticipantRequestPermissionType.SubOwner),
@@ -39,11 +39,11 @@ internal static class BudgetPermissionDataInitializer
                     AssignParticipantRequestPermissionType.SubOwner)
             ];
 
-        BudgetIds.AddRange(collection: budgetPermissionRequestIds.Select(selector: x => x.budgetId));
+        BudgetIds.AddRange(collection: budgetPermissionModels.Select(selector: x => x.budgetId));
         int iteration = 0;
 
         foreach ((Guid budgetId, string email, AssignParticipantRequestPermissionType permissionType) in
-                 budgetPermissionRequestIds)
+                 budgetPermissionModels)
         {
             iteration++;
 
@@ -63,8 +63,9 @@ internal static class BudgetPermissionDataInitializer
                             correlationId: correlationId,
                             requestedBy: TestClient.ClientId, timestamp: clock.UtcNow,
                             module: ModuleNames.BudgetSharingModule),
-                        Payload: new AssignParticipantRequest(BudgetId: budgetId, Email: email,
-                            PermissionType: permissionType)), cancellationToken: cancellationToken);
+                        Payload: new AssignParticipantRequest(BudgetPermissionRequestId: Guid.NewGuid(),
+                            BudgetId: budgetId,
+                            Email: email, PermissionType: permissionType)), cancellationToken: cancellationToken);
 
             BudgetPermissionIds.Add(item: createBudgetPermissionResponse!.BudgetPermissionId);
             BudgetPermissionRequestIds.Add(item: assignParticipantResponse!.BudgetPermissionRequestId);

--- a/src/Api/Tests/Expenso.Api.Tests.E2E/UserPreferences/Preferences/CreatePreferences.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.E2E/UserPreferences/Preferences/CreatePreferences.cs
@@ -12,11 +12,12 @@ internal sealed class CreatePreferences : PreferencesTestBase
         // Arrange
         _httpClient.SetFakeBearerToken(token: _claims);
         Guid userId = Guid.NewGuid();
+        Guid preferenceId = Guid.NewGuid();
         const string requestPath = "user-preferences/preferences";
 
         // Act
         HttpResponseMessage response = await _httpClient.PostAsJsonAsync(requestUri: requestPath,
-            value: new CreatePreferenceRequest(UserId: userId));
+            value: new CreatePreferenceRequest(PreferenceId: preferenceId, UserId: userId));
 
         // Assert
         AssertResponseCreated(response: response);
@@ -25,6 +26,7 @@ internal sealed class CreatePreferences : PreferencesTestBase
             await response.Content.ReadFromJsonAsync<CreatePreferenceResponse>();
 
         responseContent.Should().NotBeNull();
+        responseContent?.PreferenceId.Should().Be(expected: preferenceId);
     }
 
     [Test]

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/AssignParticipant/AssignParticipantCommandHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/AssignParticipant/AssignParticipantCommandHandler.cs
@@ -12,15 +12,15 @@ namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Write.Assig
 internal sealed class
     AssignParticipantCommandHandler : ICommandHandler<AssignParticipantCommand, AssignParticipantResponse>
 {
-    private readonly IAssignParticipantionDomainService _assignParticipantionDomainService;
+    private readonly IAssignParticipationDomainService _iAssignParticipationDomainService;
     private readonly BudgetSharingSettings _budgetSharingSettings;
 
-    public AssignParticipantCommandHandler(IAssignParticipantionDomainService assignParticipantionDomainService,
+    public AssignParticipantCommandHandler(IAssignParticipationDomainService iAssignParticipationDomainService,
         BudgetSharingSettings budgetSharingSettings)
     {
-        _assignParticipantionDomainService = assignParticipantionDomainService ??
+        _iAssignParticipationDomainService = iAssignParticipationDomainService ??
                                              throw new ArgumentNullException(
-                                                 paramName: nameof(assignParticipantionDomainService));
+                                                 paramName: nameof(iAssignParticipationDomainService));
 
         _budgetSharingSettings = budgetSharingSettings ??
                                  throw new ArgumentNullException(paramName: nameof(budgetSharingSettings));
@@ -30,7 +30,7 @@ internal sealed class
         CancellationToken cancellationToken)
     {
         BudgetPermissionRequest budgetPermissionRequest =
-            await _assignParticipantionDomainService.AssignParticipantAsync(
+            await _iAssignParticipationDomainService.AssignParticipantAsync(
                 budgetPermissionRequestId: BudgetPermissionRequestId.New(
                     value: command.Payload?.BudgetPermissionRequestId ?? Guid.NewGuid()),
                 budgetId: BudgetId.New(value: command.Payload?.BudgetId), email: command.Payload?.Email,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/AssignParticipant/AssignParticipantCommandHandler.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/AssignParticipant/AssignParticipantCommandHandler.cs
@@ -3,6 +3,7 @@ using Expenso.BudgetSharing.Application.BudgetPermissionRequests.Write.AssignPar
 using Expenso.BudgetSharing.Application.Shared.Settings;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 using Expenso.Shared.Commands;
 
@@ -30,6 +31,8 @@ internal sealed class
     {
         BudgetPermissionRequest budgetPermissionRequest =
             await _assignParticipantionDomainService.AssignParticipantAsync(
+                budgetPermissionRequestId: BudgetPermissionRequestId.New(
+                    value: command.Payload?.BudgetPermissionRequestId ?? Guid.NewGuid()),
                 budgetId: BudgetId.New(value: command.Payload?.BudgetId), email: command.Payload?.Email,
                 permissionType: AssignParticipantRequestMap.ToPermissionType(
                     assignParticipantRequestPermissionType: command.Payload?.PermissionType),

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/AssignParticipant/DTO/Request/AssignParticipantRequest.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissionRequests/Write/AssignParticipant/DTO/Request/AssignParticipantRequest.cs
@@ -3,4 +3,5 @@ namespace Expenso.BudgetSharing.Application.BudgetPermissionRequests.Write.Assig
 public sealed record AssignParticipantRequest(
     Guid BudgetId,
     string Email,
-    AssignParticipantRequestPermissionType PermissionType);
+    AssignParticipantRequestPermissionType PermissionType,
+    Guid? BudgetPermissionRequestId = null);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Write/CreateBudgetPermission/DTO/Request/CreateBudgetPermissionRequest.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Application/BudgetPermissions/Write/CreateBudgetPermission/DTO/Request/CreateBudgetPermissionRequest.cs
@@ -1,7 +1,7 @@
 namespace Expenso.BudgetSharing.Application.BudgetPermissions.Write.CreateBudgetPermission.DTO.Request;
 
 public sealed record CreateBudgetPermissionRequest(
-    Guid? BudgetPermissionId,
     Guid BudgetId,
     string BudgetCode,
-    Guid OwnerId);
+    Guid OwnerId,
+    Guid? BudgetPermissionId = null);

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/BudgetPermissionRequest.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/BudgetPermissionRequest.cs
@@ -71,9 +71,9 @@ public sealed class BudgetPermissionRequest : IAggregateRoot
         return _domainEventsSource.GetDomainEvents();
     }
 
-    internal static BudgetPermissionRequest Create(BudgetId budgetId, BudgetCode budgetCode, PersonId ownerId,
-        PersonId personId, PermissionType permissionType, DateAndTime expirationDate, DateAndTime submissionDate,
-        BudgetPermissionRequestId? budgetPermissionRequestId = null)
+    internal static BudgetPermissionRequest Create(BudgetPermissionRequestId? budgetPermissionRequestId,
+        BudgetId budgetId, BudgetCode budgetCode, PersonId ownerId, PersonId personId, PermissionType permissionType,
+        DateAndTime expirationDate, DateAndTime submissionDate)
     {
         return new BudgetPermissionRequest(
             id: budgetPermissionRequestId ?? BudgetPermissionRequestId.New(value: Guid.NewGuid()), budgetId: budgetId,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService.cs
@@ -16,14 +16,14 @@ using Expenso.Shared.System.Types.Clock;
 
 namespace Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services;
 
-internal sealed class AssignParticipantionDomainService : IAssignParticipantionDomainService
+internal sealed class AssignParticipationDomainService : IAssignParticipationDomainService
 {
     private readonly IBudgetPermissionRepository _budgetPermissionRepository;
     private readonly IBudgetPermissionRequestRepository _budgetPermissionRequestRepository;
     private readonly IClock _clock;
     private readonly IIamProxy _iamProxy;
 
-    public AssignParticipantionDomainService(IIamProxy iamProxy,
+    public AssignParticipationDomainService(IIamProxy iamProxy,
         IBudgetPermissionRequestRepository budgetPermissionRequestRepository, IClock clock,
         IBudgetPermissionRepository budgetPermissionRepository)
     {

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService.cs
@@ -1,6 +1,7 @@
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Repositories;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Rules;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.BudgetPermissions;
 using Expenso.BudgetSharing.Domain.BudgetPermissions.Repositories;
 using Expenso.BudgetSharing.Domain.Shared.Rules;
@@ -38,7 +39,8 @@ internal sealed class AssignParticipantionDomainService : IAssignParticipantionD
         _iamProxy = iamProxy ?? throw new ArgumentNullException(paramName: nameof(iamProxy));
     }
 
-    public async Task<BudgetPermissionRequest> AssignParticipantAsync(BudgetId budgetId, string? email,
+    public async Task<BudgetPermissionRequest> AssignParticipantAsync(
+        BudgetPermissionRequestId? budgetPermissionRequestId, BudgetId budgetId, string? email,
         PermissionType? permissionType, int expirationDays, CancellationToken cancellationToken)
     {
         BudgetPermission? budgetPermission =
@@ -96,7 +98,8 @@ internal sealed class AssignParticipantionDomainService : IAssignParticipantionD
                 budgetPermissionRequests: budgetPermissionRequests))
         ]);
 
-        BudgetPermissionRequest budgetPermissionRequest = BudgetPermissionRequest.Create(budgetId: budgetId,
+        BudgetPermissionRequest budgetPermissionRequest = BudgetPermissionRequest.Create(
+            budgetPermissionRequestId: budgetPermissionRequestId, budgetId: budgetId,
             ownerId: budgetPermission!.OwnerId, budgetCode: budgetPermission.BudgetCode, personId: participantId,
             permissionType: permissionType!, expirationDate: expirationDate, submissionDate: submissionDate);
 

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/Interfaces/IAssignParticipantionDomainService.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/Interfaces/IAssignParticipantionDomainService.cs
@@ -1,9 +1,11 @@
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 
 namespace Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
 
 public interface IAssignParticipantionDomainService
 {
-    Task<BudgetPermissionRequest> AssignParticipantAsync(BudgetId budgetId, string? email,
-        PermissionType? permissionType, int expirationDays, CancellationToken cancellationToken);
+    Task<BudgetPermissionRequest> AssignParticipantAsync(BudgetPermissionRequestId? budgetPermissionRequestId,
+        BudgetId budgetId, string? email, PermissionType? permissionType, int expirationDays,
+        CancellationToken cancellationToken);
 }

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/Interfaces/IAssignParticipationDomainService.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/BudgetPermissionRequests/Services/Interfaces/IAssignParticipationDomainService.cs
@@ -3,7 +3,7 @@ using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 
 namespace Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
 
-public interface IAssignParticipantionDomainService
+public interface IAssignParticipationDomainService
 {
     Task<BudgetPermissionRequest> AssignParticipantAsync(BudgetPermissionRequestId? budgetPermissionRequestId,
         BudgetId budgetId, string? email, PermissionType? permissionType, int expirationDays,

--- a/src/BudgetSharing/Expenso.BudgetSharing.Domain/Extensions.cs
+++ b/src/BudgetSharing/Expenso.BudgetSharing.Domain/Extensions.cs
@@ -10,7 +10,7 @@ public static class Extensions
 {
     public static void AddDomain(this IServiceCollection services)
     {
-        services.AddScoped<IAssignParticipantionDomainService, AssignParticipantionDomainService>();
+        services.AddScoped<IAssignParticipationDomainService, AssignParticipationDomainService>();
         services.AddScoped<IConfirmParticipantionDomainService, ConfirmParticipantionDomainService>();
         services.AddScoped<IIamProxyService, IamProxyService>();
 

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/BudgetPermissionRequestTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/BudgetPermissionRequestTestBase.cs
@@ -1,4 +1,5 @@
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests;
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 using Expenso.Shared.System.Types.Clock;
 
@@ -13,6 +14,9 @@ internal abstract class BudgetPermissionRequestTestBase : DomainTestBase<BudgetP
     public void SetUp()
     {
         _clockMock.Setup(expression: x => x.UtcNow).Returns(value: DateTimeOffset.UtcNow);
+
+        _defaultBudgetPermissionId =
+            BudgetPermissionRequestId.New(value: new Guid(g: "96316d8b-e18b-4578-ac0e-df9cdc337155"));
         _defaultPersonId = PersonId.New(value: new Guid(g: "be3220e9-54da-4013-a0dd-72db7ef3b53e"));
         _defaultOwnerId = PersonId.New(value: new Guid(g: "fabfae93-2257-4bbc-ac90-8319d42c4836"));
         _defaultBudgetId = BudgetId.New(value: new Guid(g: "c3e578f3-8ec1-4fbd-b680-64f9bbc77eba"));
@@ -22,6 +26,7 @@ internal abstract class BudgetPermissionRequestTestBase : DomainTestBase<BudgetP
 
     protected const int Expiration = 3;
     protected readonly Mock<IClock> _clockMock = new();
+    protected BudgetPermissionRequestId _defaultBudgetPermissionId = null!;
     protected BudgetId _defaultBudgetId = null!;
     protected BudgetCode _budgetCode = null!;
     protected PersonId _defaultOwnerId = null!;
@@ -35,7 +40,8 @@ internal abstract class BudgetPermissionRequestTestBase : DomainTestBase<BudgetP
             .Setup(expression: x => x.UtcNow)
             .Returns(value: DateTimeOffset.UtcNow.AddMinutes(minutes: delay ?? -30));
 
-        BudgetPermissionRequest testCandidate = BudgetPermissionRequest.Create(budgetId: _defaultBudgetId,
+        BudgetPermissionRequest testCandidate = BudgetPermissionRequest.Create(
+            budgetPermissionRequestId: _defaultBudgetPermissionId, budgetId: _defaultBudgetId,
             ownerId: _defaultOwnerId, personId: _defaultPersonId, permissionType: _defaultPermissionType,
             expirationDate: _clockMock.Object.UtcNow.AddDays(days: Expiration),
             submissionDate: _clockMock.Object.UtcNow, budgetCode: _budgetCode);

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Create.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/BudgetPermissionRequests/Create.cs
@@ -47,7 +47,8 @@ internal sealed class Create : BudgetPermissionRequestTestBase
         _clockMock.Setup(expression: x => x.UtcNow).Returns(value: new DateTime(year: 2021, month: 1, day: 1));
 
         // Act
-        Func<Task> action = () => Task.FromResult(result: BudgetPermissionRequest.Create(budgetId: _defaultBudgetId,
+        Func<Task> action = () => Task.FromResult(result: BudgetPermissionRequest.Create(
+            budgetPermissionRequestId: _defaultBudgetPermissionId, budgetId: _defaultBudgetId,
             ownerId: _defaultOwnerId, personId: _defaultPersonId, budgetCode: _budgetCode,
             permissionType: _defaultPermissionType, expirationDate: _clockMock.Object.UtcNow.AddDays(days: 0),
             submissionDate: _clockMock.Object.UtcNow));

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipantAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipantAsync.cs
@@ -37,7 +37,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
 
         // Act
         BudgetPermissionRequest budgetPermissionRequest = await TestCandidate.AssignParticipantAsync(
-            budgetId: _budgetId, email: _email, permissionType: _permissionType, expirationDays: ExpirationDays,
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
+            permissionType: _permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
         // Assert
@@ -68,7 +69,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .ReturnsAsync(value: null);
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: _permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
@@ -97,7 +99,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
                 identifier: _email));
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: _permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
@@ -127,7 +130,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             });
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: _permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
@@ -157,7 +161,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .ReturnsAsync(value: _budgetPermission);
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: _permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
@@ -186,7 +191,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .Setup(expression: x => x.GetByBudgetIdAsync(_budgetId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _budgetPermission);
 
-        BudgetPermissionRequest otherBudgetPermissionRequest = BudgetPermissionRequest.Create(budgetId: _budgetId,
+        BudgetPermissionRequest otherBudgetPermissionRequest = BudgetPermissionRequest.Create(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId,
             budgetCode: _budgetCode, ownerId: _ownerId, personId: _participantId, permissionType: permissionType,
             expirationDate: _clockMock.Object.UtcNow.AddDays(days: 10), submissionDate: _clockMock.Object.UtcNow);
 
@@ -196,7 +202,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .ReturnsAsync(value: [otherBudgetPermissionRequest]);
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
@@ -226,10 +233,12 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
 
         IReadOnlyCollection<BudgetPermissionRequest> otherBudgetPermissionRequests =
         [
-            BudgetPermissionRequest.Create(budgetId: _budgetId, ownerId: _ownerId, personId: _participantId,
+            BudgetPermissionRequest.Create(budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId,
+                ownerId: _ownerId, personId: _participantId,
                 budgetCode: _budgetCode, permissionType: PermissionType.Reviewer,
                 expirationDate: _clockMock.Object.UtcNow.AddDays(days: 4), submissionDate: _clockMock.Object.UtcNow),
-            BudgetPermissionRequest.Create(budgetId: _budgetId, ownerId: _ownerId, personId: _participantId,
+            BudgetPermissionRequest.Create(budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId,
+                ownerId: _ownerId, personId: _participantId,
                 budgetCode: _budgetCode, permissionType: PermissionType.SubOwner,
                 expirationDate: _clockMock.Object.UtcNow.AddDays(days: 7), submissionDate: _clockMock.Object.UtcNow)
         ];
@@ -240,7 +249,8 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
             .ReturnsAsync(value: otherBudgetPermissionRequests);
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: PermissionType.Owner, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 
@@ -268,13 +278,15 @@ internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTes
                 x.GetUncompletedByPersonIdAsync(_budgetId, _participantId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(value:
             [
-                BudgetPermissionRequest.Create(budgetId: _budgetId, ownerId: _ownerId, personId: _participantId,
+                BudgetPermissionRequest.Create(budgetPermissionRequestId: _budgetPermissionRequestId,
+                    budgetId: _budgetId, ownerId: _ownerId, personId: _participantId,
                     budgetCode: _budgetCode, permissionType: PermissionType.Owner,
                     expirationDate: _clockMock.Object.UtcNow.AddDays(days: 4), submissionDate: _clockMock.Object.UtcNow)
             ]);
 
         // Act
-        Func<Task> action = () => TestCandidate.AssignParticipantAsync(budgetId: _budgetId, email: _email,
+        Func<Task> action = () => TestCandidate.AssignParticipantAsync(
+            budgetPermissionRequestId: _budgetPermissionRequestId, budgetId: _budgetId, email: _email,
             permissionType: permissionType, expirationDays: ExpirationDays,
             cancellationToken: It.IsAny<CancellationToken>());
 

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipantDomainServiceTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipantDomainServiceTestBase.cs
@@ -1,5 +1,6 @@
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Repositories;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.BudgetPermissions;
 using Expenso.BudgetSharing.Domain.BudgetPermissions.Repositories;
 using Expenso.BudgetSharing.Domain.BudgetPermissions.ValueObjects;
@@ -32,6 +33,7 @@ internal abstract class AssignParticipantDomainServiceTestBase : DomainTestBase<
         _budgetPermissionId = BudgetPermissionId.New(value: Guid.NewGuid());
         _participantId = PersonId.New(value: Guid.NewGuid());
         _budgetId = BudgetId.New(value: Guid.NewGuid());
+        _budgetPermissionRequestId = BudgetPermissionRequestId.New(value: Guid.NewGuid());
         _ownerId = PersonId.New(value: Guid.NewGuid());
         _budgetCode = BudgetCode.New(value: "BDGT/1021/12/2024");
 
@@ -86,8 +88,8 @@ internal abstract class AssignParticipantDomainServiceTestBase : DomainTestBase<
     ];
 
     protected readonly PermissionType _permissionType = PermissionType.SubOwner;
-    protected BudgetPermissionId _budgetPermissionId = null!;
     protected BudgetId _budgetId = null!;
+    protected BudgetPermissionRequestId _budgetPermissionRequestId = null!;
     protected BudgetCode _budgetCode = null!;
     protected BudgetPermission _budgetPermission = null!;
     protected Mock<IBudgetPermissionRepository> _budgetPermissionRepositoryMock = null!;
@@ -98,4 +100,5 @@ internal abstract class AssignParticipantDomainServiceTestBase : DomainTestBase<
     protected Mock<IIamProxy> _iamProxyMock = null!;
     protected PersonId _ownerId = null!;
     protected PersonId _participantId = null!;
+    private BudgetPermissionId _budgetPermissionId = null!;
 }

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipationAsync.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipationAsync.cs
@@ -15,7 +15,7 @@ namespace Expenso.BudgetSharing.Tests.UnitTests.Domain.BudgetPermissionRequests.
     AssignParticipantionDomainService;
 
 [TestFixture]
-internal sealed class AssignParticipantAsync : AssignParticipantDomainServiceTestBase
+internal sealed class AssignParticipationAsync : AssignParticipationDomainServiceTestBase
 {
     [Test]
     public async Task Should_CreateBudgetPermissionRequest_InPositiveCase()

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipationDomainServiceTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/AssignParticipantionDomainService/AssignParticipationDomainServiceTestBase.cs
@@ -1,4 +1,5 @@
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Repositories;
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.BudgetPermissions;
@@ -15,7 +16,7 @@ namespace Expenso.BudgetSharing.Tests.UnitTests.Domain.BudgetPermissionRequests.
     AssignParticipantionDomainService;
 
 [TestFixture]
-internal abstract class AssignParticipantDomainServiceTestBase : DomainTestBase<IAssignParticipantionDomainService>
+internal abstract class AssignParticipationDomainServiceTestBase : DomainTestBase<IAssignParticipationDomainService>
 {
     [SetUp]
     public void SetUp()
@@ -51,8 +52,7 @@ internal abstract class AssignParticipantDomainServiceTestBase : DomainTestBase<
 
         _email = _getUserByEmailResponse.Email;
 
-        TestCandidate = new BudgetSharing.Domain.BudgetPermissionRequests.Services.AssignParticipantionDomainService(
-            iamProxy: _iamProxyMock.Object,
+        TestCandidate = new AssignParticipationDomainService(iamProxy: _iamProxyMock.Object,
             budgetPermissionRequestRepository: _budgetPermissionRequestRepositoryMock.Object, clock: _clockMock.Object,
             budgetPermissionRepository: _budgetPermissionRepositoryMock.Object);
     }

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/BudgetPermissionRequestExpirationDomainService/BudgetPermissionRequestExpirationDomainServiceTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/BudgetPermissionRequestExpirationDomainService/BudgetPermissionRequestExpirationDomainServiceTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using Expenso.BudgetSharing.Domain.BudgetPermissionRequests;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Repositories;
 using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.Services.Interfaces;
+using Expenso.BudgetSharing.Domain.BudgetPermissionRequests.ValueObjects;
 using Expenso.BudgetSharing.Domain.Shared.ValueObjects;
 using Expenso.Shared.System.Types.Clock;
 
@@ -25,10 +26,12 @@ internal abstract class
 
         _clockMock.Setup(expression: x => x.UtcNow).Returns(value: baseDate);
 
-        _budgetPermissionRequest = BudgetPermissionRequest.Create(budgetId: BudgetId.New(value: Guid.NewGuid()),
-            personId: PersonId.New(value: Guid.NewGuid()), ownerId: PersonId.New(value: Guid.NewGuid()),
-            budgetCode: BudgetCode.New(value: "BDGT/123/12/2024"), permissionType: PermissionType.SubOwner,
-            expirationDate: baseDate.AddDays(days: DefaultExpirationDays), submissionDate: baseDate);
+        _budgetPermissionRequest = BudgetPermissionRequest.Create(
+            budgetPermissionRequestId: BudgetPermissionRequestId.New(value: Guid.NewGuid()),
+            budgetId: BudgetId.New(value: Guid.NewGuid()), personId: PersonId.New(value: Guid.NewGuid()),
+            ownerId: PersonId.New(value: Guid.NewGuid()), budgetCode: BudgetCode.New(value: "BDGT/123/12/2024"),
+            permissionType: PermissionType.SubOwner, expirationDate: baseDate.AddDays(days: DefaultExpirationDays),
+            submissionDate: baseDate);
 
         TestCandidate =
             new BudgetSharing.Domain.BudgetPermissionRequests.Services.BudgetPermissionRequestExpirationDomainService(

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationDomainServiceTestBase.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.UnitTests/Domain/BudgetPermissionRequests/Services/ConfirmParticipationDomainService/ConfirmParticipationDomainServiceTestBase.cs
@@ -27,6 +27,7 @@ internal abstract class ConfirmParticipationDomainServiceTestBase : DomainTestBa
         _userPreferencesProxyMock = new Mock<IUserPreferencesProxy>();
         _clockMock = new Mock<IClock>();
         _budgetId = BudgetId.New(value: Guid.NewGuid());
+        _budgetPermissionRequestId = BudgetPermissionRequestId.New(value: Guid.NewGuid());
         BudgetPermissionId budgetPermissionId = BudgetPermissionId.New(value: Guid.NewGuid());
         PersonId ownerId = PersonId.New(value: Guid.NewGuid());
         BudgetCode budgetCode = BudgetCode.New(value: "BDGT/11/12/2024");
@@ -36,13 +37,12 @@ internal abstract class ConfirmParticipationDomainServiceTestBase : DomainTestBa
 
         _clockMock.Setup(expression: x => x.UtcNow).Returns(value: submissionDate);
 
-        _budgetPermissionRequest = BudgetPermissionRequest.Create(budgetId: _budgetId,
-            personId: PersonId.New(value: Guid.NewGuid()), ownerId: ownerId, budgetCode: budgetCode,
-            permissionType: PermissionType.SubOwner, expirationDate: _clockMock.Object.UtcNow.AddDays(days: 3),
-            submissionDate: _clockMock.Object.UtcNow);
+        _budgetPermissionRequest = BudgetPermissionRequest.Create(budgetPermissionRequestId: _budgetPermissionRequestId,
+            budgetId: _budgetId, personId: PersonId.New(value: Guid.NewGuid()), ownerId: ownerId,
+            budgetCode: budgetCode, permissionType: PermissionType.SubOwner,
+            expirationDate: _clockMock.Object.UtcNow.AddDays(days: 3), submissionDate: _clockMock.Object.UtcNow);
 
         _clockMock.Setup(expression: x => x.UtcNow).Returns(value: submissionDate.AddMinutes(minutes: 30));
-        _budgetPermissionRequestId = _budgetPermissionRequest.Id;
 
         _budgetPermissionRepositoryMock
             .Setup(expression: x => x.IsUnique(budgetPermissionId, _budgetId, ownerId,

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Read/GetJobEntries/GetJobEntriesQueryHandler.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Read/GetJobEntries/GetJobEntriesQueryHandler.cs
@@ -23,22 +23,14 @@ internal sealed class
     public async Task<IReadOnlyCollection<GetJobEntriesResponse>?> HandleAsync(GetJobEntriesQuery query,
         CancellationToken cancellationToken)
     {
-        JobEntryQuerySpecification querySpecification = new()
-        {
-            JobEntryId = query.Payload?.JobEntryId,
-            JobInstanceId = query.Payload?.JobInstanceId,
-            JobEntryStatusIds = query.Payload?.JobEntryStatusIds,
-            MoreThanRetries = query.Payload?.MoreThanRetries,
-            IsCompleted = query.Payload?.IsCompleted,
-            HasRun = query.Payload?.HasRun,
-            IsActive = query.Payload?.IsActive,
-            HasTriggers = query.Payload?.HasTriggers,
-            Includes = query.Payload?.Includes.SafeCast<JobEntryIncludes, GetJobEntriesRequestJobEntryIncludes>()
-        };
+        JobEntryQuerySpecification querySpecification = new(JobEntryId: query.Payload?.JobEntryId,
+            JobInstanceId: query.Payload?.JobInstanceId, JobEntryStatusIds: query.Payload?.JobEntryStatusIds,
+            MoreThanRetries: query.Payload?.MoreThanRetries, IsCompleted: query.Payload?.IsCompleted,
+            HasRun: query.Payload?.HasRun, IsActive: query.Payload?.IsActive, HasTriggers: query.Payload?.HasTriggers,
+            Includes: query.Payload?.Includes.SafeCast<JobEntryIncludes, GetJobEntriesRequestJobEntryIncludes>());
 
         IReadOnlyCollection<JobEntry> jobEntries = await _jobEntryRepository.GetJobEntriesAsync(
-            querySpecification: querySpecification,
-                cancellationToken: cancellationToken);
+            querySpecification: querySpecification, cancellationToken: cancellationToken);
 
         return GetJobEntriesResponseMap.MapTo(jobEntries: jobEntries);
     }

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Read/GetJobEntry/GetJobEntryQueryHandler.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Read/GetJobEntry/GetJobEntryQueryHandler.cs
@@ -23,12 +23,9 @@ internal sealed class GetJobEntryQueryHandler : IQueryHandler<GetJobEntryQuery, 
 
     public async Task<GetJobEntryResponse?> HandleAsync(GetJobEntryQuery query, CancellationToken cancellationToken)
     {
-        JobEntryQuerySpecification querySpecification = new()
-        {
-            JobEntryId = query.Payload?.JobEntryId,
-            Includes = query.Payload?.Includes.SafeCast<JobEntryIncludes, GetJobEntryRequestJobEntryIncludes>(),
-            UseTracking = false
-        };
+        JobEntryQuerySpecification querySpecification = new(JobEntryId: query.Payload?.JobEntryId,
+            Includes: query.Payload?.Includes.SafeCast<JobEntryIncludes, GetJobEntryRequestJobEntryIncludes>(),
+            UseTracking: false);
 
         JobEntry? jobEntry = await _jobEntryRepository.GetJobEntryAsync(querySpecification: querySpecification,
             cancellationToken: cancellationToken);

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Shared/BackgroundJobs/JobsExecutions/JobExecution.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Shared/BackgroundJobs/JobsExecutions/JobExecution.cs
@@ -60,12 +60,8 @@ internal sealed class JobExecution : IJobExecution
                 return;
             }
 
-            JobEntryQuerySpecification querySpecification = new()
-            {
-                JobInstanceId = jobInstanceId,
-                IsActive = true,
-                UseTracking = true
-            };
+            JobEntryQuerySpecification querySpecification =
+                new(JobInstanceId: jobInstanceId, IsActive: true, UseTracking: true);
 
             IReadOnlyCollection<JobEntry> jobEntries = await _jobEntryRepository.GetJobEntriesAsync(
                 querySpecification: querySpecification, cancellationToken: stoppingToken);

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Write/CancelJobEntry/CancelJobEntryCommandHandler.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Write/CancelJobEntry/CancelJobEntryCommandHandler.cs
@@ -24,13 +24,8 @@ internal sealed class CancelJobEntryCommandHandler : ICommandHandler<CancelJobEn
 
     public async Task HandleAsync(CancelJobEntryCommand command, CancellationToken cancellationToken)
     {
-        JobEntryQuerySpecification querySpecification = new()
-        {
-            JobEntryId = command.Payload?.JobEntryId,
-            IsActive = true,
-            UseTracking = true
-        };
-
+        JobEntryQuerySpecification querySpecification =
+            new(JobEntryId: command.Payload?.JobEntryId, IsActive: true, UseTracking: true);
         JobEntry? jobEntry = await _jobEntryRepository.GetJobEntryAsync(querySpecification: querySpecification,
             cancellationToken: cancellationToken);
 

--- a/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Write/RegisterJobEntry/RegisterJobEntryCommandHandler.cs
+++ b/src/TimeManagement/Expenso.TimeManagement.Core/Application/JobEntries/Write/RegisterJobEntry/RegisterJobEntryCommandHandler.cs
@@ -63,19 +63,16 @@ internal sealed class
 
         if (command.Payload?.JobEntryId is not null)
         {
-            JobEntryQuerySpecification jobEntryQuerySpecification = new()
-            {
-                JobEntryId = command.Payload?.JobEntryId,
-                UseTracking = false
-            };
+            JobEntryQuerySpecification jobEntryQuerySpecification =
+                new(JobEntryId: command.Payload?.JobEntryId, UseTracking: false);
 
             JobEntry? existingJobEntry = await _jobEntryRepository.GetJobEntryAsync(
                 querySpecification: jobEntryQuerySpecification, cancellationToken: cancellationToken);
 
             if (existingJobEntry is not null)
             {
-                throw new ConflictException(
-                    message: $"Job entry with id {command.Payload?.JobEntryId} already exists.");
+                throw ConflictException.AlreadyExists(resourceName: nameof(JobEntry),
+                    identifierType: IdentifierType.Query(), identifier: jobEntryQuerySpecification);
             }
         }
 

--- a/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Application/JobEntries/Write/RegisterJob/RegisterJobEntryCommandHandler/HandleAsync.cs
+++ b/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Application/JobEntries/Write/RegisterJob/RegisterJobEntryCommandHandler/HandleAsync.cs
@@ -51,6 +51,8 @@ internal sealed class HandleAsync : RegisterJobEntryCommandHandlerTestBase
             .Setup(expression: x => x.GetAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>(), true))
             .ReturnsAsync(value: JobEntryStatus.Running);
 
+        JobEntryQuerySpecification jobEntryQuerySpecification = new(JobEntryId: _jobEntryId, UseTracking: false);
+
         _jobEntryRepositoryMock
             .Setup(expression: x =>
                 x.GetJobEntryAsync(It.IsAny<JobEntryQuerySpecification>(), It.IsAny<CancellationToken>()))
@@ -67,7 +69,7 @@ internal sealed class HandleAsync : RegisterJobEntryCommandHandlerTestBase
         await action
             .Should()
             .ThrowAsync<ConflictException>()
-            .WithMessage(expectedWildcardPattern: $"Job entry with id {_jobEntryId} already exists.");
+            .WithMessage(expectedWildcardPattern: $"JobEntry with query {jobEntryQuerySpecification} already exists.");
     }
 
     [Test]

--- a/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Persistence/EfCore/Repositories/JobEntryRepository/GetJobEntriesAsync.cs
+++ b/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Persistence/EfCore/Repositories/JobEntryRepository/GetJobEntriesAsync.cs
@@ -12,10 +12,7 @@ internal sealed class GetJobEntriesAsync : JobEntryRepositoryTestBase
     public async Task Should_ReturnJobEntries_When_JobEntryExists()
     {
         // Arrange
-        JobEntryQuerySpecification querySpecification = new()
-        {
-            UseTracking = false
-        };
+        JobEntryQuerySpecification querySpecification = new(UseTracking: false);
 
         // Act
         IReadOnlyCollection<JobEntry> jobEntries =

--- a/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Persistence/EfCore/Repositories/JobEntryRepository/GetJobEntryAsync.cs
+++ b/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Persistence/EfCore/Repositories/JobEntryRepository/GetJobEntryAsync.cs
@@ -12,11 +12,7 @@ internal sealed class GetJobEntryAsync : JobEntryRepositoryTestBase
     public async Task Should_ReturnJobEntry_When_JobEntryExists(Guid jobEntryId)
     {
         // Arrange
-        JobEntryQuerySpecification querySpecification = new()
-        {
-            JobEntryId = jobEntryId,
-            UseTracking = false
-        };
+        JobEntryQuerySpecification querySpecification = new(JobEntryId: jobEntryId, UseTracking: false);
 
         // Act
         JobEntry? jobEntry = await TestCandidate.GetJobEntryAsync(querySpecification: querySpecification,

--- a/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Persistence/EfCore/Repositories/JobEntryRepository/GetJobEntryAsync.cs
+++ b/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.UnitTests/Persistence/EfCore/Repositories/JobEntryRepository/GetJobEntryAsync.cs
@@ -22,4 +22,19 @@ internal sealed class GetJobEntryAsync : JobEntryRepositoryTestBase
         jobEntry.Should().NotBeNull();
         jobEntry.Should().Be(expected: JobEntries.Single(predicate: x => x.Id == jobEntryId));
     }
+
+    [Test]
+    public async Task Should_ReturnNull_When_JobEntryDoesNotExist()
+    {
+        // Arrange
+        Guid nonExistentId = Guid.NewGuid();
+        JobEntryQuerySpecification querySpecification = new(JobEntryId: nonExistentId, UseTracking: false);
+
+        // Act
+        JobEntry? jobEntry = await TestCandidate.GetJobEntryAsync(querySpecification: querySpecification,
+            cancellationToken: default);
+
+        // Assert
+        jobEntry.Should().BeNull();
+    }
 }

--- a/src/UserPreferences/Expenso.UserPreferences.Api/UserPreferencesModule.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Api/UserPreferencesModule.cs
@@ -112,7 +112,7 @@ public sealed class UserPreferencesModule : IModuleDefinition
             {
                 CreatePreferenceResponse response = await handler.HandleAsync(
                     command: new CreatePreferenceCommand(MessageContext: messageContextFactory.Current(),
-                        Payload: new CreatePreferenceRequest(UserId: model.UserId)),
+                        Payload: new CreatePreferenceRequest(PreferenceId: model.PreferenceId, UserId: model.UserId)),
                     cancellationToken: cancellationToken);
 
                 return Results.CreatedAtRoute(routeName: getPreferenceEndpointRegistration.Name, routeValues: new

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/CreatePreferenceCommandHandler.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/CreatePreferenceCommandHandler.cs
@@ -25,15 +25,10 @@ internal sealed class
         CancellationToken cancellationToken)
     {
         Guid userId = command.Payload!.UserId;
-
-        PreferenceQuerySpecification querySpecification = new()
-        {
-            UserId = userId,
-            UseTracking = false
-        };
+        PreferenceQuerySpecification querySpecification = new(UserId: command.Payload?.UserId, UseTracking: false);
 
         bool dbUserPreferencesExists = await _preferencesRepository.ExistsAsync(querySpecification: querySpecification,
-                cancellationToken: cancellationToken);
+            cancellationToken: cancellationToken);
 
         if (dbUserPreferencesExists)
         {
@@ -41,7 +36,23 @@ internal sealed class
                 identifierType: IdentifierType.Query(), identifier: querySpecification);
         }
 
-        Preference preferenceToCreate = PreferenceFactory.Create(userId: userId);
+        if (command.Payload?.PreferenceId is not null)
+        {
+            querySpecification =
+                new PreferenceQuerySpecification(PreferenceId: command.Payload.PreferenceId, UseTracking: false);
+
+            bool dbPreferenceExists = await _preferencesRepository.ExistsAsync(querySpecification: querySpecification,
+                cancellationToken: cancellationToken);
+
+            if (dbPreferenceExists)
+            {
+                throw ConflictException.AlreadyExists(resourceName: nameof(Preference),
+                    identifierType: IdentifierType.Query(), identifier: querySpecification);
+            }
+        }
+
+        Preference preferenceToCreate =
+            PreferenceFactory.Create(preferenceId: command.Payload?.PreferenceId, userId: userId);
 
         Preference preference =
             await _preferencesRepository.CreateAsync(preference: preferenceToCreate,

--- a/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/Factories/PreferenceFactory.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Core/Application/Preferences/Write/Commands/CreatePreference/Factories/PreferenceFactory.cs
@@ -4,7 +4,7 @@ namespace Expenso.UserPreferences.Core.Application.Preferences.Write.Commands.Cr
 
 internal static class PreferenceFactory
 {
-    public static Preference Create(Guid userId, Guid? preferenceId = null)
+    public static Preference Create(Guid? preferenceId, Guid userId)
     {
         Guid id = preferenceId ?? Guid.NewGuid();
 

--- a/src/UserPreferences/Expenso.UserPreferences.Shared/DTO/API/CreatePreference/Request/CreatePreferenceRequest.cs
+++ b/src/UserPreferences/Expenso.UserPreferences.Shared/DTO/API/CreatePreference/Request/CreatePreferenceRequest.cs
@@ -1,3 +1,3 @@
 namespace Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Request;
 
-public sealed record CreatePreferenceRequest(Guid UserId);
+public sealed record CreatePreferenceRequest(Guid UserId, Guid? PreferenceId = null);

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/CreatePreferences.cs
@@ -32,7 +32,7 @@ internal sealed class CreatePreferences : UserPreferencesProxyTestBase
             expression: x => x.SendAsync<CreatePreferenceCommand, CreatePreferenceResponse>(
                 new CreatePreferenceCommand(
                     MessageContextFactoryMock.Object.FromParent(_currentMessageContext, It.IsAny<string?>(),
-                        It.IsAny<Guid>()), new CreatePreferenceRequest(_userId)), It.IsAny<CancellationToken>()),
+                        It.IsAny<Guid>()), new CreatePreferenceRequest(_userId, null)), It.IsAny<CancellationToken>()),
             times: Times.Once);
     }
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/UserPreferencesProxyTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Proxy/UserPreferencesProxy/UserPreferencesProxyTestBase.cs
@@ -1,5 +1,6 @@
 using Expenso.Shared.Commands.Dispatchers;
 using Expenso.Shared.Queries.Dispatchers;
+using Expenso.Shared.System.Modules.Constants;
 using Expenso.Shared.System.Types.Messages.Interfaces;
 using Expenso.UserPreferences.Shared;
 using Expenso.UserPreferences.Shared.DTO.API.CreatePreference.Response;
@@ -13,13 +14,14 @@ internal abstract class UserPreferencesProxyTestBase : TestBase<IUserPreferences
     [SetUp]
     public void SetUp()
     {
+        _preferenceId = Guid.NewGuid();
         _userId = Guid.NewGuid();
         _id = Guid.NewGuid();
         _queryDispatcherMock = new Mock<IQueryDispatcher>();
         _commandDispatcherMock = new Mock<ICommandDispatcher>();
 
-        _currentMessageContext =
-            MessageContextFactoryMock.Object.Current(messageId: It.IsAny<Guid?>(), moduleId: It.IsAny<string?>());
+        _currentMessageContext = MessageContextFactoryMock.Object.Current(messageId: It.IsAny<Guid?>(),
+            moduleId: ModuleNames.UserPreferencesModule);
 
         _getPreferencesExternalResponse = new GetPreferencesResponse(Id: _id, UserId: _userId,
             FinancePreference: new GetPreferencesResponseFinancePreference(AllowAddFinancePlanSubOwners: false,
@@ -43,4 +45,5 @@ internal abstract class UserPreferencesProxyTestBase : TestBase<IUserPreferences
     private Guid _id;
     protected Mock<IQueryDispatcher> _queryDispatcherMock = null!;
     protected Guid _userId;
+    protected Guid _preferenceId;
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreference/GetPreferenceQueryHandlerTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreference/GetPreferenceQueryHandlerTestBase.cs
@@ -13,15 +13,15 @@ internal abstract class GetPreferenceQueryHandlerTestBase : TestBase<GetPreferen
     [SetUp]
     public void SetUp()
     {
-        _id = Guid.NewGuid();
-        _preference = PreferenceFactory.Create(userId: Guid.NewGuid());
+        _preferenceId = Guid.NewGuid();
+        _preference = PreferenceFactory.Create(preferenceId: _preferenceId, userId: Guid.NewGuid());
         _getPreferenceResponse = GetPreferenceResponseMap.MapTo(preference: _preference);
         _preferenceRepositoryMock = new Mock<IPreferencesRepository>();
         TestCandidate = new GetPreferenceQueryHandler(preferencesRepository: _preferenceRepositoryMock.Object);
     }
 
     protected GetPreferenceResponse _getPreferenceResponse = null!;
-    protected Guid _id;
+    protected Guid _preferenceId;
     protected Preference _preference = null!;
     protected Mock<IPreferencesRepository> _preferenceRepositoryMock = null!;
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreference/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreference/HandleAsync.cs
@@ -14,12 +14,12 @@ internal sealed class HandleAsync : GetPreferenceQueryHandlerTestBase
     {
         // Arrange
         GetPreferenceQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new GetPreferenceRequest(PreferenceId: _id,
+            Payload: new GetPreferenceRequest(PreferenceId: _preferenceId,
                 Includes: It.IsAny<GetPreferenceRequestPreferenceIncludes>()));
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
+                x.GetAsync(new PreferenceQuerySpecification(_preferenceId, null, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _preference);
 
@@ -32,7 +32,7 @@ internal sealed class HandleAsync : GetPreferenceQueryHandlerTestBase
         result.Should().BeEquivalentTo(expectation: _getPreferenceResponse);
 
         _preferenceRepositoryMock.Verify(expression: x =>
-            x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
+            x.GetAsync(new PreferenceQuerySpecification(_preferenceId, null, false, It.IsAny<PreferenceIncludes>()),
                 It.IsAny<CancellationToken>()), times: Times.Once);
     }
 
@@ -41,7 +41,7 @@ internal sealed class HandleAsync : GetPreferenceQueryHandlerTestBase
     {
         // Arrange
         GetPreferenceQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new GetPreferenceRequest(PreferenceId: _id,
+            Payload: new GetPreferenceRequest(PreferenceId: _preferenceId,
                 Includes: It.IsAny<GetPreferenceRequestPreferenceIncludes>()));
 
         // Act

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/GetPreferenceForCurrentUserQueryHandlerTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferenceForCurrentUser/GetPreferenceForCurrentUserQueryHandlerTestBase.cs
@@ -17,7 +17,8 @@ internal abstract class
     public void SetUp()
     {
         _userId = Guid.NewGuid();
-        _preference = PreferenceFactory.Create(userId: _userId);
+        _preferenceId = Guid.NewGuid();
+        _preference = PreferenceFactory.Create(preferenceId: _preferenceId, userId: _userId);
         _getPreferenceResponse = GetPreferenceForCurrentUserResponseMap.MapTo(preference: _preference);
         _preferenceRepositoryMock = new Mock<IPreferencesRepository>();
         _userContextAccessorMock = new Mock<IExecutionContextAccessor>();
@@ -36,6 +37,7 @@ internal abstract class
     protected Preference _preference = null!;
     protected Mock<IPreferencesRepository> _preferenceRepositoryMock = null!;
     protected Mock<IExecutionContextAccessor> _userContextAccessorMock = null!;
-    protected Mock<IUserContext> _userContextMock = null!;
     protected Guid _userId;
+    private Guid _preferenceId;
+    private Mock<IUserContext> _userContextMock = null!;
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferences/GetPreferencesQueryHandlerTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferences/GetPreferencesQueryHandlerTestBase.cs
@@ -13,15 +13,15 @@ internal abstract class GetPreferencesQueryHandlerTestBase : TestBase<GetPrefere
     [SetUp]
     public void SetUp()
     {
-        _id = Guid.NewGuid();
+        _preferenceId = Guid.NewGuid();
         _userId = Guid.NewGuid();
-        _preference = PreferenceFactory.Create(userId: _userId);
+        _preference = PreferenceFactory.Create(preferenceId: _preferenceId, userId: _userId);
         _getPreferenceResponse = GetPreferencesResponseMap.MapTo(preference: _preference);
         _preferenceRepositoryMock = new Mock<IPreferencesRepository>();
         TestCandidate = new GetPreferencesQueryHandler(preferencesRepository: _preferenceRepositoryMock.Object);
     }
 
-    protected Guid _id;
+    protected Guid _preferenceId;
     protected Guid _userId;
     protected GetPreferencesResponse _getPreferenceResponse = null!;
     protected Preference _preference = null!;

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferences/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Read/Queries/GetPreferences/HandleAsync.cs
@@ -14,12 +14,12 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
     {
         // Arrange
         GetPreferencesQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new GetPreferencesRequest(PreferenceId: _id,
+            Payload: new GetPreferencesRequest(PreferenceId: _preferenceId,
                 Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()));
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
-                x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
+                x.GetAsync(new PreferenceQuerySpecification(_preferenceId, null, false, It.IsAny<PreferenceIncludes>()),
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(value: _preference);
 
@@ -32,7 +32,7 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
         result.Should().BeEquivalentTo(expectation: _getPreferenceResponse);
 
         _preferenceRepositoryMock.Verify(expression: x =>
-            x.GetAsync(new PreferenceQuerySpecification(_id, null, false, It.IsAny<PreferenceIncludes>()),
+            x.GetAsync(new PreferenceQuerySpecification(_preferenceId, null, false, It.IsAny<PreferenceIncludes>()),
                 It.IsAny<CancellationToken>()), times: Times.Once);
     }
 
@@ -69,7 +69,7 @@ internal sealed class HandleAsync : GetPreferencesQueryHandlerTestBase
     {
         // Arrange
         GetPreferencesQuery query = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new GetPreferencesRequest(PreferenceId: _id,
+            Payload: new GetPreferencesRequest(PreferenceId: _preferenceId,
                 Includes: It.IsAny<GetPreferencesRequestPreferenceIncludes>()));
 
         // Act

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/CreatePreferenceCommandHandlerTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/CreatePreferenceCommandHandlerTestBase.cs
@@ -15,7 +15,8 @@ internal abstract class CreatePreferenceCommandHandlerTestBase : TestBase<
     public void SetUp()
     {
         _userId = Guid.NewGuid();
-        _preference = PreferenceFactory.Create(userId: _userId);
+        _preferenceId = Guid.NewGuid();
+        _preference = PreferenceFactory.Create(preferenceId: _preferenceId, userId: _userId);
         _preferenceRepositoryMock = new Mock<IPreferencesRepository>();
         _createPreferenceResponse = CreatePreferenceResponseMap.MapTo(preference: _preference);
 
@@ -28,4 +29,5 @@ internal abstract class CreatePreferenceCommandHandlerTestBase : TestBase<
     protected Preference _preference = null!;
     protected Mock<IPreferencesRepository> _preferenceRepositoryMock = null!;
     protected Guid _userId;
+    protected Guid _preferenceId;
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/HandleAsync.cs
@@ -17,7 +17,7 @@ internal sealed class HandleAsync : CreatePreferenceCommandHandlerTestBase
     {
         // Arrange
         CreatePreferenceCommand command = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new CreatePreferenceRequest(UserId: _userId));
+            Payload: new CreatePreferenceRequest(PreferenceId: _preferenceId, UserId: _userId));
 
         _preferenceRepositoryMock
             .Setup(expression: x =>
@@ -46,7 +46,7 @@ internal sealed class HandleAsync : CreatePreferenceCommandHandlerTestBase
     {
         // Arrange
         CreatePreferenceCommand command = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new CreatePreferenceRequest(UserId: _userId));
+            Payload: new CreatePreferenceRequest(PreferenceId: _preferenceId, UserId: _userId));
 
         PreferenceQuerySpecification querySpecification = new()
         {

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/HandleAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandHandler/HandleAsync.cs
@@ -42,7 +42,39 @@ internal sealed class HandleAsync : CreatePreferenceCommandHandlerTestBase
     }
 
     [Test]
-    public async Task Should_ThrowConflictException_When_CreatingPreferenceAndPreferenceAlreadyExists()
+    public async Task Should_ThrowConflictException_When_CreatingPreferenceWithSameIdAlreadyExists()
+    {
+        // Arrange
+        CreatePreferenceCommand command = new(MessageContext: MessageContextFactoryMock.Object.Current(),
+            Payload: new CreatePreferenceRequest(PreferenceId: _preferenceId, UserId: _userId));
+
+        PreferenceQuerySpecification querySpecification = new()
+        {
+            PreferenceId = _preferenceId,
+            UseTracking = false
+        };
+
+        _preferenceRepositoryMock
+            .Setup(expression: x => x.ExistsAsync(querySpecification, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(value: true);
+
+        // Act
+        // Assert
+        Func<Task> act = () =>
+            TestCandidate.HandleAsync(command: command, cancellationToken: It.IsAny<CancellationToken>());
+
+        await act
+            .Should()
+            .ThrowAsync<ConflictException>()
+            .WithMessage(
+                expectedWildcardPattern: $"{nameof(Preference)} with query {querySpecification} already exists.")
+            .Where(exceptionExpression: x =>
+                x.ResourceName == nameof(Preference) && x.IdentifierType == IdentifierType.Query() &&
+                (PreferenceQuerySpecification?)x.Identifier == querySpecification);
+    }
+    
+    [Test]
+    public async Task Should_ThrowConflictException_When_CreatingPreferenceForUserAlreadyExists()
     {
         // Arrange
         CreatePreferenceCommand command = new(MessageContext: MessageContextFactoryMock.Object.Current(),

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/CreatePreferenceCommandValidatorTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/CreatePreferenceCommandValidatorTestBase.cs
@@ -15,7 +15,7 @@ internal abstract class CreatePreferenceCommandValidatorTestBase : TestBase<
     {
         _createPreferenceCommand = new CreatePreferenceCommand(
             MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new CreatePreferenceRequest(UserId: Guid.NewGuid()));
+            Payload: new CreatePreferenceRequest(PreferenceId: Guid.NewGuid(), UserId: Guid.NewGuid()));
 
         TestCandidate =
             new Core.Application.Preferences.Write.Commands.CreatePreference.CreatePreferenceCommandValidator(

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/Validate.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/CreatePreference/CreatePreferenceCommandValidator/Validate.cs
@@ -43,7 +43,7 @@ internal sealed class Validate : CreatePreferenceCommandValidatorTestBase
         Guid userId = Guid.Empty;
 
         CreatePreferenceCommand command = new(MessageContext: MessageContextFactoryMock.Object.Current(),
-            Payload: new CreatePreferenceRequest(UserId: userId));
+            Payload: new CreatePreferenceRequest(PreferenceId: Guid.NewGuid(), UserId: userId));
 
         // Act
         ValidationResult validationResult = TestCandidate.Validate(instance: command);

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandHandler/UpdatePreferenceCommandHandlerTestBase.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Application/Preferences/Write/UpdatePreference/UpdatePreferenceCommandHandler/UpdatePreferenceCommandHandlerTestBase.cs
@@ -15,7 +15,8 @@ internal abstract class UpdatePreferenceCommandHandlerTestBase : TestBase<
     {
         _id = Guid.NewGuid();
         _userId = Guid.NewGuid();
-        _preference = PreferenceFactory.Create(userId: _userId);
+        _preferenceId = Guid.NewGuid();
+        _preference = PreferenceFactory.Create(preferenceId: _preferenceId, userId: _userId);
         _preferenceRepositoryMock = new Mock<IPreferencesRepository>();
         _messageBrokerMock = new Mock<IMessageBroker>();
 
@@ -27,6 +28,7 @@ internal abstract class UpdatePreferenceCommandHandlerTestBase : TestBase<
     protected Mock<IMessageBroker> _messageBrokerMock = null!;
     protected Preference _preference = null!;
     protected Mock<IPreferencesRepository> _preferenceRepositoryMock = null!;
-    protected Guid _userId;
     protected Guid _id;
+    private Guid _userId;
+    private Guid _preferenceId;
 }

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/CreateAsync.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.UnitTests/Persistence/EfCore/Repositories/PreferencesRepository/CreateAsync.cs
@@ -10,7 +10,7 @@ internal sealed class CreateAsync : PreferenceRepositoryTestBase
     public async Task Should_CreatePreference_When_PreferenceDoesNotExist()
     {
         // Arrange
-        Preference preference = PreferenceFactory.Create(userId: Guid.NewGuid());
+        Preference preference = PreferenceFactory.Create(preferenceId: Guid.NewGuid(), userId: Guid.NewGuid());
 
         _preferenceDbSetMock
             .Setup(expression: x => x.AddAsync(preference, It.IsAny<CancellationToken>()))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced optional `BudgetPermissionRequestId` parameter in various command and request classes to enhance budget permission management.
	- Updated `CreatePreferenceRequest` to require both `UserId` and `PreferenceId` for creating preferences.

- **Bug Fixes**
	- Corrected naming inconsistencies in service and test classes related to participant management.

- **Documentation**
	- Improved clarity in test setups and assertions by ensuring the correct identifiers are used for preferences and budget permissions.

- **Refactor**
	- Enhanced object instantiation clarity by using constructor parameters instead of object initializers in several classes.

- **Tests**
	- Updated tests to reflect new parameter requirements and improved exception handling scenarios related to budget permissions and preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->