### PR TITLE
Rename arch test properties

### DIFF
--- a/src/Api/Tests/Expenso.Api.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/Api/Tests/Expenso.Api.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,14 +9,14 @@ namespace Expenso.Api.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Exception"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
         ])

--- a/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/BudgetSharing/Tests/Expenso.BudgetSharing.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,18 +9,18 @@ namespace Expenso.BudgetSharing.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Module",
             "Extensions"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
-        ], publicTypes:
+        ], publicNamespaces:
         [
             "DTO",
             "Domain",

--- a/src/Communication/Tests/Expenso.Communication.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/Communication/Tests/Expenso.Communication.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,18 +9,18 @@ namespace Expenso.Communication.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Module",
             "Extensions"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
-        ], publicTypes:
+        ], publicNamespaces:
         [
             "DTO"
         ])

--- a/src/DocumentManagement/Tests/Expenso.DocumentManagement.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/DocumentManagement/Tests/Expenso.DocumentManagement.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,18 +9,18 @@ namespace Expenso.DocumentManagement.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Module",
             "Extensions"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
-        ], publicTypes:
+        ], publicNamespaces:
         [
             "DTO"
         ])

--- a/src/IAM/Tests/Expenso.IAM.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/IAM/Tests/Expenso.IAM.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,18 +9,18 @@ namespace Expenso.IAM.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Module",
             "Extensions"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
-        ], publicTypes:
+        ], publicNamespaces:
         [
             "DTO",
             "Settings"

--- a/src/Shared/Tests/Expenso.Shared.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/Shared/Tests/Expenso.Shared.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -10,7 +10,7 @@ namespace Expenso.Shared.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "TestBase",
             "InMemoryFakeLogger",
@@ -25,18 +25,18 @@ internal sealed class AccessModifierTests : AccessModifierTestBase
             "Clock",
             "ProviderTimeZoneResult",
             "RequestTimeZone"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program",
             "Exception",
             "RichTestObject"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program",
             "Exception",
             "RichTestObject"
-        ], publicTypes:
+        ], publicNamespaces:
         [
             "DTO",
             "Settings",

--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.ArchTests/AccessModifierTestBase.cs
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.ArchTests/AccessModifierTestBase.cs
@@ -8,20 +8,20 @@ namespace Expenso.Shared.Tests.Utils.ArchTests;
 
 public abstract class AccessModifierTestBase : TestBase
 {
-    private readonly string[] _notInternal;
-    private readonly string[] _notSealed;
-    private readonly string[] _notAbstract;
-    private readonly string[]? _publicTypes;
-    private readonly string[]? _namespacesToExclude;
+    private readonly string[] _notInternalTypes;
+    private readonly string[] _notSealedTypes;
+    private readonly string[] _notAbstractTypes;
+    private readonly string[]? _publicNamespaces;
+    private readonly string[]? _excludedNamespaces;
 
-    protected AccessModifierTestBase(string[] notInternal, string[] notSealed, string[] notAbstract,
-        string[]? publicTypes = null, string[]? namespacesToExclude = null)
+    protected AccessModifierTestBase(string[] notInternalTypes, string[] notSealedTypes, string[] notAbstractTypes,
+        string[]? publicNamespaces = null, string[]? excludedNamespaces = null)
     {
-        _notInternal = notInternal;
-        _notSealed = notSealed;
-        _notAbstract = notAbstract;
-        _publicTypes = publicTypes;
-        _namespacesToExclude = namespacesToExclude;
+        _notInternalTypes = notInternalTypes;
+        _notSealedTypes = notSealedTypes;
+        _notAbstractTypes = notAbstractTypes;
+        _publicNamespaces = publicNamespaces;
+        _excludedNamespaces = excludedNamespaces;
     }
 
     protected abstract IReadOnlyCollection<Assembly> TestClassesAssemblies { get; }
@@ -32,19 +32,19 @@ public abstract class AccessModifierTestBase : TestBase
         ConditionList? types =
             Types.InAssemblies(assemblies: TestClassesAssemblies).Should().BeClasses().And().BePublic();
 
-        types = _notInternal.Aggregate(seed: types,
+        types = _notInternalTypes.Aggregate(seed: types,
             func: (current, skippedTypeName) => current.And().NotHaveNameMatching(pattern: skippedTypeName));
 
-        if (_publicTypes is not null or [])
+        if (_publicNamespaces is not null or [])
         {
-            types = _publicTypes?.Aggregate(seed: types,
+            types = _publicNamespaces?.Aggregate(seed: types,
                 func: (current, skippedTypeName) =>
                     current.And().NotResideInNamespaceContaining(name: skippedTypeName));
         }
 
-        if (_namespacesToExclude is not null or [])
+        if (_excludedNamespaces is not null or [])
         {
-            types = _namespacesToExclude?.Aggregate(seed: types,
+            types = _excludedNamespaces?.Aggregate(seed: types,
                 func: (current, skippedNamespace) => current?.And().NotResideInNamespace(name: skippedNamespace));
         }
 
@@ -65,12 +65,12 @@ public abstract class AccessModifierTestBase : TestBase
             .And()
             .NotBeSealed();
 
-        types = _notSealed.Aggregate(seed: types,
+        types = _notSealedTypes.Aggregate(seed: types,
             func: (current, skippedTypeName) => current.And().NotHaveNameMatching(pattern: skippedTypeName));
 
-        if (_namespacesToExclude is not null or [])
+        if (_excludedNamespaces is not null or [])
         {
-            types = _namespacesToExclude?.Aggregate(seed: types,
+            types = _excludedNamespaces?.Aggregate(seed: types,
                 func: (current, skippedNamespace) => current.And().NotResideInNamespace(name: skippedNamespace));
         }
 
@@ -87,12 +87,12 @@ public abstract class AccessModifierTestBase : TestBase
             .And()
             .NotBeAbstract();
 
-        types = _notAbstract.Aggregate(seed: types,
+        types = _notAbstractTypes.Aggregate(seed: types,
             func: (current, skippedTypeName) => current.And().NotHaveNameMatching(pattern: skippedTypeName));
 
-        if (_namespacesToExclude is not null or [])
+        if (_excludedNamespaces is not null or [])
         {
-            types = _namespacesToExclude?.Aggregate(seed: types,
+            types = _excludedNamespaces?.Aggregate(seed: types,
                 func: (current, skippedNamespace) => current.And().NotResideInNamespace(name: skippedNamespace));
         }
 

--- a/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/TimeManagement/Tests/Expenso.TimeManagement.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,7 +9,7 @@ namespace Expenso.TimeManagement.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Module",
             "Extensions",
@@ -19,14 +19,14 @@ internal sealed class AccessModifierTests : AccessModifierTestBase
             "Command",
             "IntegrationEvent",
             "AllowedEvents"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
-        ], namespacesToExclude:
+        ], excludedNamespaces:
         [
             "Expenso.TimeManagement.Core.Persistence.EfCore.Migrations",
             "Expenso.TimeManagement.Core.Application.Shared.Settings"

--- a/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
+++ b/src/UserPreferences/Tests/Expenso.UserPreferences.Tests.ArchTests/AccessModifiers/AccessModifierTests.cs
@@ -9,7 +9,7 @@ namespace Expenso.UserPreferences.Tests.ArchTests.AccessModifiers;
 [TestFixture]
 internal sealed class AccessModifierTests : AccessModifierTestBase
 {
-    public AccessModifierTests() : base(notInternal:
+    public AccessModifierTests() : base(notInternalTypes:
         [
             "Module",
             "Extensions",
@@ -19,14 +19,14 @@ internal sealed class AccessModifierTests : AccessModifierTestBase
             "Command",
             "IntegrationEvent",
             "Payload"
-        ], notSealed:
+        ], notSealedTypes:
         [
             "TestBase",
             "Program"
-        ], notAbstract:
+        ], notAbstractTypes:
         [
             "Program"
-        ], namespacesToExclude:
+        ], excludedNamespaces:
         [
             "Expenso.UserPreferences.Core.Persistence.EfCore.Migrations"
         ])


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated parameter names in `AccessModifierTests` and `AccessModifierTestBase` classes across multiple test projects
  - Renamed parameters to be more descriptive and consistent, such as:
    - `notInternal` → `notInternalTypes`
    - `notSealed` → `notSealedTypes`
    - `notAbstract` → `notAbstractTypes`
    - `publicTypes` → `publicNamespaces`
    - `namespacesToExclude` → `excludedNamespaces`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->