### PR TITLE
Froze FluentAssertions at 7.0.0

### DIFF
--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.ArchTests/Expenso.Shared.Tests.Utils.ArchTests.csproj
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.ArchTests/Expenso.Shared.Tests.Utils.ArchTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="FluentAssertions" Version="[7.0.0]"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>
         <PackageReference Include="NetArchTest.Rules" Version="1.3.2"/>
         <PackageReference Include="NUnit" Version="4.2.2"/>

--- a/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/Expenso.Shared.Tests.Utils.UnitTests.csproj
+++ b/src/Shared/Tests/Utils/Expenso.Shared.Tests.Utils.UnitTests/Expenso.Shared.Tests.Utils.UnitTests.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Castle.Core" Version="5.1.1"/>
-        <PackageReference Include="FluentAssertions" Version="6.12.0"/>
+        <PackageReference Include="FluentAssertions" Version="[7.0.0]"/>
         <PackageReference Include="FluentValidation" Version="11.10.0"/>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.8"/>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0"/>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated `FluentAssertions` package to version 7.0.0 in test utility projects
	- Upgraded package version to allow for future compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->